### PR TITLE
feat: allow configurable database table prefix for player data tables

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ This plugin is a hybrid build and the same JAR file works on all supported platf
   * **Resilient Connection Pooling:** Uses HikariCP with optimized settings to ensure that the database connection is resilient to network issues and database restarts.
   * **Granular Sync Control**: Enable or disable synchronization for any specific data type via `config.yml`.
   * **Server/World Blacklist**: Prevent synchronization on specific servers or worlds.
+  * **Configurable Table Names**: Set a custom prefix for database tables to avoid conflicts.
   * **Configurable & Flexible:** Easily connect to your MySQL database and configure settings for your server environment.
 
 ## Installation
@@ -87,7 +88,11 @@ debug: false
 # A unique name for this server. This is CRITICAL for data locking.
 # Each server connected to the same database MUST have a unique name.
 # Example: "survival-1", "creative", "lobby"
+# Example: "survival-1", "creative", "lobby"
 server-id: "default-server"
+
+# Set to prefix the player_data table (e.g., 'mc_data_bridge_'). Leave empty for default.
+table-prefix: ""
 
 # The duration in milliseconds after which a player data lock is considered expired.
 # This prevents players from being permanently locked out if a server crashes.

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.digitalserverhost.plugins</groupId>
     <artifactId>mc-data-bridge</artifactId>
-    <version>2.0.3</version>
+    <version>2.0.4</version>
 
     <name>mc-data-bridge</name>
     <url>https://mc.digitalserverhost.com</url>

--- a/release-notes.md
+++ b/release-notes.md
@@ -1,19 +1,14 @@
-# Release Notes - MC Data Bridge v2.0.3
+# Release Notes - MC Data Bridge v2.0.4
 
 ## 🆕 New Features
-*   **Granular Data Synchronization**: You can now toggle exactly what data is synced in `config.yml`. Added `sync-data` section.
-*   **Ender Chest Sync**: Added support for synchronizing Ender Chest contents! (Disabled by default, enable in config).
-*   **Advancements Integration**: Added support for standard Advancements and Recipes! (Disabled by default).
-*   **Admin Unlock Command**: Added `/databridge unlock <player>` to manually release a stuck lock.
-*   **Blacklist**: Added `sync-blacklist` to disable synchronization on specific servers or worlds.
+*   **Configurable Table Prefix**: Added a new `table-prefix` option in `config.yml`.
+    *   This allows you to specify a prefix (e.g., `mc_data_bridge_`) for the database table.
+    *   Useful for avoiding conflicts with other plugins in the same database that use the same table name or running multiple instances of the plugin.
 
-## 🛠 Improvements & Optimizations
-*   **Configurable Heartbeat**: Added `lock-heartbeat-seconds` to control how often the data lock is refreshed.
-*   **Better Messages**: Updated message handling to use Adventure API for full modern chat component support.
-*   **Database Check**: Added a startup check to warn if your database schema for `data` is `LONGTEXT` instead of the recommended `MEDIUMBLOB`.
+## 🛠 Improvements
+*   **Backward Compatibility**: The default behavior remains unchanged. If `table-prefix` is not set or left empty, the plugin continues to use `player_data` as the table name.
+*   **Auto-Configuration**: The new `table-prefix` setting will be automatically added to your existing `config.yml` on startup.
+*   **Smart Migration**: If you set a prefix (e.g., `survival_`) and have an existing `player_data` table, the plugin will **automatically rename** your old table to the new name (e.g., `survival_player_data`) on first startup, preserving all your player data. this is only done once from the default table name to the new prefix. You can manually rename the table if you need to change the prefix after setting it.
 
-## ⚠️ Important Notes
-*   **Configuration Update**: The plugin now features a **Smart Auto-Updater**. On startup, it will detect any missing configuration keys (like the new `sync-data` section) and safely append them to your existing `config.yml`. **You do NOT need to reset your config.**
-*   **Schema Optimization**: The plugin now supports `LONGBLOB` for the `data` column, which is more efficient than `LONGTEXT`.
-    *   **Automatic Migration**: A new check will run on startup. If you are using the old `LONGTEXT` format, the plugin will automatically attempt to migrate your table to `LONGBLOB` if the config option `auto-update-schema` is set to `true` (which is the default for updated configs).
-    *   **Manual**: If you prefer, you can manually run `ALTER TABLE player_data MODIFY COLUMN data LONGBLOB NULL;`.
+## ⚠️ Notes
+*   **No Schema Changes**: This update does not require any database migrations unless you intend to change the table name by setting a prefix.

--- a/src/main/java/com/digitalserverhost/plugins/listeners/PlayerListener.java
+++ b/src/main/java/com/digitalserverhost/plugins/listeners/PlayerListener.java
@@ -125,8 +125,8 @@ public class PlayerListener implements Listener, PluginMessageListener {
 
             // --- DATA IS LOCKED, PROCEED WITH LOADING ---
             try (Connection connection = databaseManager.getConnection()) {
-                PreparedStatement statement = connection
-                        .prepareStatement("SELECT data FROM player_data WHERE uuid = ?");
+                String query = "SELECT data FROM " + databaseManager.getTableName() + " WHERE uuid = ?";
+                PreparedStatement statement = connection.prepareStatement(query);
                 statement.setString(1, uuid.toString());
                 ResultSet resultSet = statement.executeQuery();
 
@@ -167,8 +167,8 @@ public class PlayerListener implements Listener, PluginMessageListener {
 
     private boolean isLockOwner(UUID uuid, String serverId) {
         try (Connection connection = databaseManager.getConnection()) {
-            PreparedStatement checkStmt = connection
-                    .prepareStatement("SELECT locking_server FROM player_data WHERE uuid = ?");
+            String query = "SELECT locking_server FROM " + databaseManager.getTableName() + " WHERE uuid = ?";
+            PreparedStatement checkStmt = connection.prepareStatement(query);
             checkStmt.setString(1, uuid.toString());
             ResultSet rs = checkStmt.executeQuery();
             if (rs.next()) {

--- a/src/main/java/com/digitalserverhost/plugins/proxy/velocity/VelocityMCDataBridge.java
+++ b/src/main/java/com/digitalserverhost/plugins/proxy/velocity/VelocityMCDataBridge.java
@@ -8,7 +8,7 @@ import com.velocitypowered.api.event.Subscribe;
 import com.velocitypowered.api.event.proxy.ProxyInitializeEvent;
 import com.velocitypowered.api.proxy.messages.MinecraftChannelIdentifier;
 
-@Plugin(id = "mc-data-bridge", name = "mc-data-bridge", version = "2.0.3", description = "A data bridge for Minecraft servers.", authors = {
+@Plugin(id = "mc-data-bridge", name = "mc-data-bridge", version = "2.0.4", description = "A data bridge for Minecraft servers.", authors = {
         "DigitalServerHost" })
 public class VelocityMCDataBridge {
 

--- a/src/main/resources/bungee.yml
+++ b/src/main/resources/bungee.yml
@@ -1,4 +1,4 @@
 name: mc-data-bridge
-version: 2.0.3
+version: 2.0.4
 main: com.digitalserverhost.plugins.proxy.bungee.BungeeMCDataBridge
 author: DigitalServerHost

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -46,6 +46,9 @@ debug: false
 # Example: "survival-1", "creative", "lobby"
 server-id: "default-server"
 
+# Set to prefix the player_data table (e.g., 'mc_data_bridge_').
+table-prefix: ""
+
 # The duration in milliseconds after which a player data lock is considered expired.
 # This prevents players from being permanently locked out if a server crashes.
 # Default: 60000 (1 minute)

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,5 +1,5 @@
 main: com.digitalserverhost.plugins.MCDataBridge
-version: 2.0.3
+version: 2.0.4
 name: mc-data-bridge
 author: DigitalServerHost
 api-version: 1.21


### PR DESCRIPTION
# Release Notes - MC Data Bridge v2.0.4
## 🆕 New Features
*   **Configurable Table Prefix**: Added a new `table-prefix` option in `config.yml`.
    *   This allows you to specify a prefix (e.g., `mc_data_bridge_`) for the database table.
    *   Useful for avoiding conflicts with other plugins in the same database that use the same table name or running multiple instances of the plugin.
## 🛠 Improvements
*   **Backward Compatibility**: The default behavior remains unchanged. If `table-prefix` is not set or left empty, the plugin continues to use `player_data` as the table name.
*   **Auto-Configuration**: The new `table-prefix` setting will be automatically added to your existing `config.yml` on startup.
*   **Smart Migration**: If you set a prefix (e.g., `survival_`) and have an existing `player_data` table, the plugin will **automatically rename** your old table to the new name (e.g., `survival_player_data`) on first startup, preserving all your player data. this is only done once from the default table name to the new prefix. You can manually rename the table if you need to change the prefix after setting it.
## ⚠️ Notes
*   **No Schema Changes**: This update does not require any database migrations unless you intend to change the table name by setting a prefix.

Closes #2
