### PR TITLE
chore: Bump version to 2.1.2, update project dependencies, and add a …

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,0 +1,27 @@
+# MC Data Bridge - Future Roadmap & TODOs
+
+### 1. Missing Data Types for Synchronization
+
+While the plugin covers core player stats, it currently does not synchronize several secondary data types:
+
+- [ ] **Player Statistics:** Vanilla Minecraft statistics (e.g., blocks mined, time played, deaths) are not currently tracked or synchronized in `PlayerData.java`.
+- [ ] **Persistent Data Container (PDC):** Custom metadata attached to players by other plugins is not serialized. This means data from other plugins (like levels, currency, or quest progress stored in PDC) will not follow the player across servers.
+- [ ] **Flight and GameMode State:** The plugin does not appear to save whether a player was flying or their specific GameMode (Creative, Survival, etc.) upon switching.
+
+### 2. Operational Limitations
+
+- [ ] **Non-MySQL Database Support:** The `DatabaseManager` is hardcoded for MySQL/MariaDB connections using the `mysql-connector-j` driver. It does not currently support PostgreSQL, MongoDB, or local SQLite storage.
+- [ ] **Automatic Backup System:** While it has a robust "Happy Path" for saving, there is no built-in system for creating periodic backups of the `player_data` table within the plugin itself; it relies on external database management for backups.
+- [ ] **In-Game Management GUI:** All management is done via the config file or the `/databridge unlock` command. There is no administrative "viewer" to see a player's synced data in-game without them being online.
+
+### 3. Features "In Progress" or Disabled by Default
+
+Some features exist in the code but are considered "New Features" and are disabled by default in the `config.yml`, requiring manual activation. We need to review/finalize these:
+
+- [ ] **Ender Chest Synchronization:** Disabled by default.
+- [ ] **Advancements and Recipes:** Disabled by default.
+- [ ] **Location Tracking:** The plugin captures location data but currently notes it is for "Logging/Admin Use Only" and is "NOT APPLIED" to the player upon joining.
+
+### 4. Cross-Platform Parity
+
+- [ ] **Command Parity:** While the Spigot/Paper version has the `/databridge unlock` command, the BungeeCord and Velocity proxy versions are primarily listeners and do not currently have an equivalent administrative command suite on the proxy level.

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.digitalserverhost.plugins</groupId>
     <artifactId>mc-data-bridge</artifactId>
-    <version>2.1.1-SNAPSHOT</version>
+    <version>2.1.2</version>
 
     <name>mc-data-bridge</name>
     <url>https://mc.digitalserverhost.com</url>
@@ -37,7 +37,7 @@
         <dependency>
             <groupId>io.papermc.paper</groupId>
             <artifactId>paper-api</artifactId>
-            <version>1.21-R0.1-SNAPSHOT</version>
+            <version>1.21.1-R0.1-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
@@ -50,7 +50,7 @@
         <dependency>
             <groupId>com.velocitypowered</groupId>
             <artifactId>velocity-api</artifactId>
-            <version>3.1.1</version>
+            <version>3.4.0</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
@@ -61,7 +61,7 @@
         <dependency>
             <groupId>com.mysql</groupId>
             <artifactId>mysql-connector-j</artifactId>
-            <version>9.5.0</version>
+            <version>9.6.0</version>
         </dependency>
         <dependency>
             <groupId>de.tr7zw</groupId>
@@ -77,19 +77,19 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>
-            <version>5.11.0</version>
+            <version>5.11.3</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
-            <version>5.12.0</version>
+            <version>5.14.2</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-junit-jupiter</artifactId>
-            <version>5.12.0</version>
+            <version>5.14.2</version>
             <scope>test</scope>
         </dependency>
         <!-- mockito-inline for mocking static methods -->
@@ -102,7 +102,7 @@
         <dependency>
             <groupId>com.github.seeseemelk</groupId>
             <artifactId>MockBukkit-v1.21</artifactId>
-            <version>3.104.0</version>
+            <version>3.133.2</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/release-notes.md
+++ b/release-notes.md
@@ -1,11 +1,17 @@
-# Release Notes - v2.1.1
+# Release Notes - v2.1.2
 
-**MC Data Bridge v2.1.1** - **Critical Bug Fix & Stability Update**
+**MC Data Bridge v2.1.2** - **Maintenance & Dependency Update**
 
-This patch release addresses a critical issue reported where players with boosted health (e.g., via Health Boost potion effects or attributes) were being kicked upon switching servers.
+This release focuses on updating core dependencies and resolving build-time compatibility issues.
 
 ---
 
-### 🐛 Bug Fixes
-*   **Fixed Kick on Server Switch with High Health:** Resolved an issue where players with health greater than 20.0 (Health Boost) would be kicked with an `IllegalArgumentException`. The plugin now safely handles this by loading potions and attributes from the database before setting the max health attribute.
+### 🔧 Maintenance
 
+- **Dependency Updates:**
+  - Updated `MockBukkit` to `3.133.2`.
+  - Updated `paper-api` to `1.21.1-R0.1-SNAPSHOT` (Fixed compatibility issues with newer MockBukkit).
+  - Updated `mysql-connector-j` to `9.6.0`.
+  - Updated `mockito` to `5.14.2`.
+
+---

--- a/src/main/resources/bungee.yml
+++ b/src/main/resources/bungee.yml
@@ -1,4 +1,4 @@
 name: mc-data-bridge
-version: 2.1.1
+version: 2.1.2
 main: com.digitalserverhost.plugins.proxy.bungee.BungeeMCDataBridge
 author: DigitalServerHost

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,5 +1,5 @@
 main: com.digitalserverhost.plugins.MCDataBridge
-version: 2.1.1
+version: 2.1.2
 name: mc-data-bridge
 author: DigitalServerHost
 api-version: 1.21


### PR DESCRIPTION
# Release Notes - v2.1.2

**MC Data Bridge v2.1.2** - **Maintenance & Dependency Update**

This release focuses on updating core dependencies and resolving build-time compatibility issues.

---

### 🔧 Maintenance

- **Dependency Updates:**
  - Updated `MockBukkit` to `3.133.2`.
  - Updated `paper-api` to `1.21.1-R0.1-SNAPSHOT` (Fixed compatibility issues with newer MockBukkit).
  - Updated `mysql-connector-j` to `9.6.0`.
  - Updated `mockito` to `5.14.2`.

---
