### PR TITLE
Hotfix: add schema migration for vanilla_stats_json column to LONGTEXT …

### DIFF
--- a/DESCRIPTION.md
+++ b/DESCRIPTION.md
@@ -187,7 +187,7 @@ In addition to the primary tracking table (`player_data`), MC Data Bridge uses c
 ### Statistics Component: `databridge_statistics`
 
 - Holds basic stats (`health` DOUBLE/REAL, `food_level` INT/INTEGER, `xp_level` INT/INTEGER, `xp_exp` FLOAT/REAL, `xp_total` INT/INTEGER, `saturation` FLOAT/REAL, `exhaustion` FLOAT/REAL).
-- Holds `vanilla_stats_json` (TEXT) containing dynamic statistics, locations, and recipe states.
+- Holds `vanilla_stats_json` (LONGTEXT/TEXT) containing dynamic statistics, locations, and recipe states.
 - Includes a `last_updated` auto-timestamp.
 
 ### Metadata Component: `databridge_metadata`

--- a/DOCUMENTATION.bbcode
+++ b/DOCUMENTATION.bbcode
@@ -123,7 +123,7 @@ For administrators managing the database directly, the plugin maintains the foll
 [*][B]xp_total[/B] (INT/INTEGER): Total experience points.
 [*][B]saturation[/B] (FLOAT/REAL): Food saturation level.
 [*][B]exhaustion[/B] (FLOAT/REAL): Food exhaustion level.
-[*][B]vanilla_stats_json[/B] (TEXT): JSON containing all synchronized vanilla statistics, location, and recipe states.
+[*][B]vanilla_stats_json[/B] (LONGTEXT/TEXT): JSON containing all synchronized vanilla statistics, location, and recipe states.
 [*][B]last_updated[/B] (TIMESTAMP/DATETIME): Auto-updated timestamp.
 [/LIST]
 

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.digitalserverhost.plugins</groupId>
     <artifactId>mc-data-bridge</artifactId>
-    <version>2.1.6-SNAPSHOT</version>
+    <version>2.1.7</version>
 
     <name>mc-data-bridge</name>
     <url>https://mc.digitalserverhost.com</url>

--- a/release-notes.bbcode
+++ b/release-notes.bbcode
@@ -1,52 +1,18 @@
-[SIZE=6][B]MC Data Bridge - Release Notes (v2.1.6)[/B][/SIZE]
+[SIZE=6][B]MC Data Bridge - Release Notes (v2.1.7)[/B][/SIZE]
 
 [SIZE=5][B]Overview[/B][/SIZE]
-[SIZE=4]Version 2.1.6 is a comprehensive feature and security update that introduces multi-server [B]Companion & Pet Synchronization[/B], implements dynamic [B]Full Vanilla Player Statistics Synchronization[/B], completes database schema normalization, adds compressed binary NBT serialization, embeds a [B]Prometheus Metrics Exporter[/B], and hardens overall network security with strict seed verification.[/SIZE]
+[SIZE=4]Version 2.1.7 is a targeted bugfix release that upgrades the [B]vanilla_stats_json[/B] column type in the statistics component table to [B]LONGTEXT[/B] (for MySQL/MariaDB), preventing potential data truncation issues when synchronizing large volumes of vanilla player statistics. It also introduces automatic schema migration for existing databases.[/SIZE]
 
 [CENTER]----------------------------------------------------------------[/CENTER]
 
-[SIZE=5][B]Key Features & Improvements[/B][/SIZE]
+[SIZE=5][B]Changes in v2.1.7[/B][/SIZE]
 
-[SIZE=4][B]📊 Full Vanilla Player Statistics Synchronization[/B][/SIZE]
+[SIZE=4][B]🗄️ Database Schema Upgrade & Migration[/B][/SIZE]
 [LIST]
-[*][B]Dynamic Statistics Sync:[/B] Replaced the legacy hardcoded list of 16 statistics with a dynamic, version-independent synchronization loop that covers all vanilla player statistics.
-[*][B]Qualified/Typed Statistics Support:[/B] Fully syncs all typed statistics requiring qualifiers—including blocks mined, items crafted/used/broken/picked up/dropped, and entities killed or killed by (e.g., [I]MINE_BLOCK:STONE[/I], [I]KILL_ENTITY:ZOMBIE[/I], [I]USE_ITEM:IRON_PICKAXE[/I]).
-[*][B]Intelligent State Application:[/B] Minimizes database updates and server overhead by only applying statistic changes when values differ from the server's current values.
-[*][B]State Cleanup & Resets:[/B] Restores synchronization parity by resetting any non-zero stats on the destination server that are not present in the player's database snapshot (setting them back to zero).
-[*][B]Graceful Version Resilience:[/B] Silently handles version-specific or custom blocks, items, and entity types, maintaining perfect compatibility across heterogeneous multi-server environments.
-[/LIST]
-
-[SIZE=4][B]🐾 Companion & Pet Synchronization[/B][/SIZE]
-[LIST]
-[*][B]Multi-Mode Synchronization:[/B] Added [I]companions.mode[/I] ([I]follow[/I], [I]return[/I], [I]untracked[/I]) to manage how pets are synced across the network.
-[*][B]Tamed Pet Persistence:[/B] Synchronizes tamed wolves, cats, parrots, and other pets across server switches.
-[*][B]Shoulder-Perched Entity Serialization:[/B] Saves and restores parrot shoulder-riding states.
-[*][B]State Preservation:[/B] Restores ownership, custom names, health/max health, and sitting status accurately.
-[*][B]NBT-Level Preservation:[/B] Utilizes NBTAPI metadata merging to preserve custom pet attributes, items, and collars.
-[*][B]Merge-on-Save Pattern:[/B] Adopts a robust relational state merging strategy to prevent NBT overrides and companion data loss across servers (critical for [I]return[/I] mode).
-[*][B]Duplication Prevention:[/B] Despawns source entities synchronously upon snapshot generation to prevent duplication exploits.
-[/LIST]
-
-[SIZE=4][B]🗄️ Relational Component Schema Normalization[/B][/SIZE]
-[LIST]
-[*][B]Companions Component Table:[/B] Introduced the [I]databridge_companions[/I] table for row-level normalized storage.
-[*][B]Optimized SQL Transactions:[/B] Avoids write-amplification by target-updating specific components (inventories, statistics, metadata, companions) independently.
-[/LIST]
-
-[SIZE=4][B]⚡ Binary NBT Serialization Option[/B][/SIZE]
-[LIST]
-[*][B]Compressed NBT Storage:[/B] Adds support for native binary compression ([I]serialization-format: binary[/I]) to dramatically reduce database footprint, storage I/O, and CPU serialization overhead.
-[/LIST]
-
-[SIZE=4][B]🛡️ Production Security Hardening[/B][/SIZE]
-[LIST]
-[*][B]Fails-Strict Safe Mode:[/B] Prevents startup if the default cryptographic seed is detected and no secure seed is configured, mitigating identity hijacking risks.
-[*][B]DDL Column Whitelists:[/B] Enforces SQL parameter and column sanitation to secure automated schema migration queries.
-[/LIST]
-
-[SIZE=4][B]📊 Embedded Prometheus Metrics Exporter[/B][/SIZE]
-[LIST]
-[*][B]Live Server Metrics:[/B] Provides an optional HTTP [I]/metrics[/I] scrape endpoint for Grafana/Prometheus tracking, exposing cache efficiency, database connection pool statistics, active transaction counts, and synchronization latencies.
+[*][B]Upgrade to LONGTEXT:[/B] Upgraded the [I]vanilla_stats_json[/I] column from [I]TEXT[/I] to [I]LONGTEXT[/I] in the [I]databridge_statistics[/I] table to support larger JSON payloads without risk of truncation.
+[*][B]Automated Migration:[/B] Added support for automatically executing the [CODE]ALTER TABLE ... MODIFY COLUMN ...[/CODE] statement when [CODE]auto-update-schema[/CODE] is set to [CODE]true[/CODE] in the configuration.
+[*][B]Admin Warning Notice:[/B] If [CODE]auto-update-schema[/CODE] is disabled, the plugin will now log a prominent warning suggesting the manual execution of the schema migration command:
+[CODE]ALTER TABLE `table_prefix_databridge_statistics` MODIFY COLUMN vanilla_stats_json LONGTEXT DEFAULT NULL;[/CODE]
 [/LIST]
 
 [CENTER]----------------------------------------------------------------[/CENTER]

--- a/release-notes.md
+++ b/release-notes.md
@@ -1,48 +1,21 @@
-# MC Data Bridge - Release Notes (v2.1.6)
+# MC Data Bridge - Release Notes (v2.1.7)
 
 ## Overview
 
-Version 2.1.6 is a comprehensive feature and security update that introduces multi-server **Companion & Pet Synchronization**, implements dynamic **Full Vanilla Player Statistics Synchronization**, completes database schema normalization, adds compressed binary NBT serialization, embeds a **Prometheus Metrics Exporter**, and hardens overall network security with strict seed verification.
+Version 2.1.7 is a targeted bugfix release that upgrades the `vanilla_stats_json` column type in the statistics component table to `LONGTEXT` (for MySQL/MariaDB), preventing potential data truncation issues when synchronizing large volumes of vanilla player statistics. It also introduces automatic schema migration for existing databases.
 
 ---
 
-## Key Features & Improvements
+## Changes in v2.1.7
 
-### 📊 Full Vanilla Player Statistics Synchronization
+### 🗄️ Database Schema Upgrade & Migration
 
-- **Dynamic Statistics Sync:** Replaced the legacy hardcoded list of 16 statistics with a dynamic, version-independent synchronization loop that covers all vanilla player statistics.
-- **Qualified/Typed Statistics Support:** Fully syncs all typed statistics requiring qualifiers—including blocks mined, items crafted/used/broken/picked up/dropped, and entities killed or killed by (e.g., `MINE_BLOCK:STONE`, `KILL_ENTITY:ZOMBIE`, `USE_ITEM:IRON_PICKAXE`).
-- **Intelligent State Application:** Minimizes database updates and server overhead by only applying statistic changes when values differ from the server's current values.
-- **State Cleanup & Resets:** Restores synchronization parity by resetting any non-zero stats on the destination server that are not present in the player's database snapshot (setting them back to zero).
-- **Graceful Version Resilience:** Silently handles version-specific or custom blocks, items, and entity types, maintaining perfect compatibility across heterogeneous multi-server environments.
-
-### 🐾 Companion & Pet Synchronization
-
-- **Multi-Mode Synchronization:** Added `companions.mode` (`follow`, `return`, `untracked`) to manage how pets are synced across the network.
-- **Tamed Pet Persistence:** Synchronizes tamed wolves, cats, parrots, and other pets across server switches.
-- **Shoulder-Perched Entity Serialization:** Saves and restores parrot shoulder-riding states.
-- **State Preservation:** Restores ownership, custom names, health/max health, and sitting status accurately.
-- **NBT-Level Preservation:** Utilizes NBTAPI metadata merging to preserve custom pet attributes, items, and collars.
-- **Merge-on-Save Pattern:** Adopts a robust relational state merging strategy to prevent NBT overrides and companion data loss across servers (critical for `return` mode).
-- **Duplication Prevention:** Despawns source entities synchronously upon snapshot generation to prevent duplication exploits.
-
-### 🗄️ Relational Component Schema Normalization
-
-- **Companions Component Table:** Introduced the `databridge_companions` table for row-level normalized storage.
-- **Optimized SQL Transactions:** Avoids write-amplification by target-updating specific components (inventories, statistics, metadata, companions) independently.
-
-### ⚡ Binary NBT Serialization Option
-
-- **Compressed NBT Storage:** Adds support for native binary compression (`serialization-format: binary`) to dramatically reduce database footprint, storage I/O, and CPU serialization overhead.
-
-### 🛡️ Production Security Hardening
-
-- **Fails-Strict Safe Mode:** Prevents startup if the default cryptographic seed is detected and no secure seed is configured, mitigating identity hijacking risks.
-- **DDL Column Whitelists:** Enforces SQL parameter and column sanitation to secure automated schema migration queries.
-
-### 📊 Embedded Prometheus Metrics Exporter
-
-- **Live Server Metrics:** Provides an optional HTTP `/metrics` scrape endpoint for Grafana/Prometheus tracking, exposing cache efficiency, database connection pool statistics, active transaction counts, and synchronization latencies.
+- **Upgrade to LONGTEXT:** Upgraded the `vanilla_stats_json` column from `TEXT` to `LONGTEXT` in the `databridge_statistics` table to support larger JSON payloads without risk of truncation.
+- **Automated Migration:** Added support for automatically executing the `ALTER TABLE ... MODIFY COLUMN ...` statement when `auto-update-schema` is set to `true` in the configuration.
+- **Admin Warning Notice:** If `auto-update-schema` is disabled, the plugin will now log a prominent warning suggesting the manual execution of the schema migration command:
+  ```sql
+  ALTER TABLE `table_prefix_databridge_statistics` MODIFY COLUMN vanilla_stats_json LONGTEXT DEFAULT NULL;
+  ```
 
 ---
 

--- a/src/main/java/com/digitalserverhost/plugins/MCDataBridge.java
+++ b/src/main/java/com/digitalserverhost/plugins/MCDataBridge.java
@@ -37,6 +37,7 @@ public class MCDataBridge extends JavaPlugin {
     private static final String CONFIG_TABLE_PREFIX = "table-prefix";
     private static final String DEFAULT_SEED = "change-me-to-a-long-random-string";
     private static final String CREATE_TABLE_IF_NOT_EXISTS = "CREATE TABLE IF NOT EXISTS ";
+    private static final String AUTO_UPDATE_SCHEMA = "auto-update-schema";
 
     @Override
     public void onEnable() {
@@ -232,7 +233,7 @@ public class MCDataBridge extends JavaPlugin {
                         "xp_total INT DEFAULT 0, " +
                         "saturation FLOAT DEFAULT 5.0, " +
                         "exhaustion FLOAT DEFAULT 0.0, " +
-                        "vanilla_stats_json TEXT DEFAULT NULL, " +
+                        "vanilla_stats_json LONGTEXT DEFAULT NULL, " +
                         "last_updated TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP, " +
                         "PRIMARY KEY (uuid)) ENGINE=InnoDB;");
                 statement.executeUpdate(CREATE_TABLE_IF_NOT_EXISTS + escapedMetadata + " (" +
@@ -247,6 +248,8 @@ public class MCDataBridge extends JavaPlugin {
                         "last_updated TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP, " +
                         "PRIMARY KEY (uuid)) ENGINE=InnoDB;");
             }
+            
+            migrateStatisticsColumn(connection, statement, dbType);
             
         } catch (Exception e) {
             getLogger().log(java.util.logging.Level.SEVERE, "CRITICAL: Error creating or updating player_data table: {0}", e.getMessage());
@@ -328,7 +331,7 @@ public class MCDataBridge extends JavaPlugin {
                 boolean needsMigration = "LONGTEXT".equalsIgnoreCase(typeName) || "TEXT".equalsIgnoreCase(typeName);
 
                 if (needsMigration) {
-                    if (getConfig().getBoolean("auto-update-schema", false)) {
+                    if (getConfig().getBoolean(AUTO_UPDATE_SCHEMA, false)) {
                         if (dbType.equals(SQLITE)) return;
                         getLogger().log(java.util.logging.Level.INFO, "Migrating 'data' column from {0} to LONGBLOB as requested...", typeName);
                         statement.executeUpdate(ALTER_TABLE_SQL + escapedTableName + " MODIFY COLUMN data LONGBLOB NULL");
@@ -343,6 +346,34 @@ public class MCDataBridge extends JavaPlugin {
 
                 if ("NO".equalsIgnoreCase(columns.getString("IS_NULLABLE"))) {
                     statement.executeUpdate(ALTER_TABLE_SQL + escapedTableName + " MODIFY COLUMN data LONGBLOB NULL");
+                }
+            }
+        }
+    }
+
+    private void migrateStatisticsColumn(Connection connection, Statement statement, String dbType) throws SQLException {
+        if (dbType.equals(SQLITE)) {
+            return;
+        }
+        String tablePrefix = getConfig().getString(CONFIG_TABLE_PREFIX, "");
+        String statisticsTable = tablePrefix + "databridge_statistics";
+        String escapedStatistics = "`" + statisticsTable + "`";
+
+        try (ResultSet columns = connection.getMetaData().getColumns(null, null, statisticsTable, "vanilla_stats_json")) {
+            if (columns.next()) {
+                String typeName = columns.getString("TYPE_NAME");
+                if ("TEXT".equalsIgnoreCase(typeName)) {
+                    if (getConfig().getBoolean(AUTO_UPDATE_SCHEMA, false)) {
+                        getLogger().log(java.util.logging.Level.INFO, "Migrating 'vanilla_stats_json' column in {0} from TEXT to LONGTEXT...", statisticsTable);
+                        statement.executeUpdate(ALTER_TABLE_SQL + escapedStatistics + " MODIFY COLUMN vanilla_stats_json LONGTEXT DEFAULT NULL");
+                    } else {
+                        getLogger().warning(BANNER);
+                        getLogger().log(java.util.logging.Level.WARNING, "!!! STATISTICS TABLE IS USING {0} FOR 'vanilla_stats_json' COLUMN. !!!", typeName);
+                        getLogger().warning("!!! IT IS HIGHLY RECOMMENDED TO SWITCH TO 'LONGTEXT' TO PREVENT DATA TRUNCATION ERRORS. !!!");
+                        getLogger().warning("!!! ENABLE 'auto-update-schema: true' IN CONFIG TO FIX AUTOMATICALLY, OR RUN: !!!");
+                        getLogger().log(java.util.logging.Level.WARNING, "!!! ALTER TABLE {0} MODIFY COLUMN vanilla_stats_json LONGTEXT DEFAULT NULL; !!!", escapedStatistics);
+                        getLogger().warning(BANNER);
+                    }
                 }
             }
         }
@@ -461,8 +492,8 @@ public class MCDataBridge extends JavaPlugin {
             appends.append("\n# Interval between lock updates.\nlock-heartbeat-seconds: 30\n");
             updated = true;
         }
-        if (!fileConfig.contains("auto-update-schema")) {
-            appends.append("\n# Automatically migrate database schema.\nauto-update-schema: true\n");
+        if (!fileConfig.contains(AUTO_UPDATE_SCHEMA)) {
+            appends.append("\n# Automatically migrate database schema.\n" + AUTO_UPDATE_SCHEMA + ": true\n");
             updated = true;
         }
         if (!fileConfig.contains("security.seed")) {

--- a/src/main/java/com/digitalserverhost/plugins/proxy/velocity/VelocityMCDataBridge.java
+++ b/src/main/java/com/digitalserverhost/plugins/proxy/velocity/VelocityMCDataBridge.java
@@ -8,7 +8,7 @@ import com.velocitypowered.api.event.Subscribe;
 import com.velocitypowered.api.event.proxy.ProxyInitializeEvent;
 import com.velocitypowered.api.proxy.messages.MinecraftChannelIdentifier;
 
-@Plugin(id = "mc-data-bridge", name = "mc-data-bridge", version = "2.1.6", authors = {
+@Plugin(id = "mc-data-bridge", name = "mc-data-bridge", version = "2.1.7", authors = {
         "DigitalServerHost" })
 public class VelocityMCDataBridge {
 

--- a/src/main/resources/bungee.yml
+++ b/src/main/resources/bungee.yml
@@ -1,4 +1,4 @@
 name: mc-data-bridge
-version: 2.1.6
+version: 2.1.7
 main: com.digitalserverhost.plugins.proxy.bungee.BungeeMCDataBridge
 author: DigitalServerHost

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,5 +1,5 @@
 main: com.digitalserverhost.plugins.MCDataBridge
-version: 2.1.6
+version: 2.1.7
 name: mc-data-bridge
 author: DigitalServerHost
 api-version: 1.21

--- a/src/main/resources/purpur.yml
+++ b/src/main/resources/purpur.yml
@@ -1,5 +1,5 @@
 main: com.digitalserverhost.plugins.MCDataBridge
-version: 2.1.6
+version: 2.1.7
 name: mc-data-bridge
 author: DigitalServerHost
 api-version: 1.21

--- a/src/main/resources/velocity-plugin.json
+++ b/src/main/resources/velocity-plugin.json
@@ -1,7 +1,7 @@
 {
   "id": "mc-data-bridge",
   "name": "mc-data-bridge",
-  "version": "2.1.6",
+  "version": "2.1.7",
   "description": "A data bridge for Minecraft servers.",
   "authors": [
     "DigitalServerHost"

--- a/src/main/resources/waterfall.yml
+++ b/src/main/resources/waterfall.yml
@@ -1,4 +1,4 @@
 name: mc-data-bridge
-version: 2.1.6
+version: 2.1.7
 main: com.digitalserverhost.plugins.proxy.bungee.BungeeMCDataBridge
 author: DigitalServerHost


### PR DESCRIPTION
`release: v2.1.7 - upgrade vanilla_stats_json to LONGTEXT & add schema migration`

### Description:
This PR Closes #26  potential data truncation bugs when synchronizing large volumes of vanilla player statistics. Under MySQL/MariaDB, the previous `TEXT` type for the `vanilla_stats_json` column was limited to 64KB, which could be exceeded on active/long-play servers with massive statistics JSON payloads. 

This release bumps the project version to `2.1.7`, upgrades the column to `LONGTEXT`, and provides a seamless migration path for existing installations.

### Changes:
* **Database Schema Upgrade:**
  * Modified the component statistics table creation script to use `LONGTEXT` instead of `TEXT` for `vanilla_stats_json` in MySQL/MariaDB.
* **Automated & Manual Migration:**
  * Implemented an automated database migration method (`migrateStatisticsColumn`) that alters the database schema dynamically during startup when `auto-update-schema` is set to `true` in `config.yml`.
  * Added console warnings with the exact SQL command to run if `auto-update-schema` is disabled.
* **Documentation & Releases:**
  * Updated `DESCRIPTION.md` and `DOCUMENTATION.bbcode` to document the new `LONGTEXT/TEXT` type.
  * Added `v2.1.7` release notes to `release-notes.md` and `release-notes.bbcode`.
* **Version Bumps:**
  * Ran the release preparation script to bump the version to `2.1.7` across `pom.xml`, `plugin.yml`, `bungee.yml`, and other platform configuration files.

### Verification Plan:
* Built the project and ran the test suite (`mvn clean test`) to verify code stability.
* Verified column schema changes against whitelists.

