### PR TITLE
2.1.8

### DIFF
--- a/DESCRIPTION.bbcode
+++ b/DESCRIPTION.bbcode
@@ -17,6 +17,8 @@ MC Data Bridge is a robust, high-performance hybrid synchronization suite for [B
 [*][B]Industrial Identity Protection:[/B] Secure tracking of [I]last_known_name[/I] and identity hashes allows for reliable UUID change detection and prevention of identity hijacking in hybrid environments.
 [*][B]Zero-Tick Identity Verification:[/B] Database locks and identity checks are performed during the [I]AsyncPlayerPreLoginEvent[/I], ensuring that player state is verified and ready before they even reach the server's "Join" state.
 [*][B]Regionalized Folia Support:[/B] Fully compatible with Folia's regionalized threading, ensuring safe data handling on modern multi-threaded server clusters.
+[*][B]Interactive Inventory & Ender Chest Inspector (`invsee` / `endersee`):[/B] Inspect offline or cross-server player inventories with default safe read-only viewing ([I]Left-Click[/I] / [I]databridge.inspect[/I]) and permission-gated interactive edit mode ([I]Right-Click[/I] or [I]--edit[/I] / [I]databridge.inspect.edit[/I]) with automatic database synchronization.
+[*][B]Full Command Tab Completion:[/B] Comprehensive auto-completion for subcommands, player names, view options, and flags.
 [*][B]Administrative Inspector GUI:[/B] Visual tools for administrators to inspect player data (inventory, stats, PDC) directly from the database without the player needing to be online.
 [*][B]Proxy-Orchestrated Saves:[/B] The proxy (Bungee/Velocity) ensures data is flushed and verified before a player connects to the destination server, eliminating race conditions.
 [*][B]Granular Sync Control:[/B] Per-component toggles in the config:
@@ -50,25 +52,35 @@ MC Data Bridge is a robust, high-performance hybrid synchronization suite for [B
 [SIZE=5]► Commands & Permissions[/SIZE]
 
 [LIST]
-[*][B]/databridge inspect <player>[/B]
+[*][B]/databridge inspect <player> [inventory|enderchest] [--edit][/B]
 [LIST]
-[*]Opens a GUI to view offline player data.
-[*]Permission: [I]databridge.admin.inspect[/I]
+[*]Opens GUI to view or edit saved player data/inventory.
+[*]Permission: [I]databridge.inspect[/I] / [I]databridge.inspect.edit[/I] (for [I]--edit[/I])
+[/LIST]
+[*][B]/databridge invsee <player> [--edit][/B]
+[LIST]
+[*]Opens saved player inventory view or edit GUI.
+[*]Permission: [I]databridge.inspect[/I] / [I]databridge.inspect.edit[/I] (for [I]--edit[/I])
+[/LIST]
+[*][B]/databridge endersee <player> [--edit][/B]
+[LIST]
+[*]Opens saved player ender chest view or edit GUI.
+[*]Permission: [I]databridge.inspect[/I] / [I]databridge.inspect.edit[/I] (for [I]--edit[/I])
 [/LIST]
 [*][B]/databridge migrate <src> <dest>[/B]
 [LIST]
 [*]Securely move data between two identities.
-[*]Permission: [I]databridge.admin.migrate[/I]
+[*]Permission: [I]databridge.admin[/I]
 [/LIST]
 [*][B]/databridge unlock <player>[/B]
 [LIST]
 [*]Manually release a stuck data lock.
-[*]Permission: [I]databridge.admin.unlock[/I]
+[*]Permission: [I]databridge.admin[/I]
 [/LIST]
 [*][B]/databridge reload[/B]
 [LIST]
 [*]Reloads the configuration and DB pool.
-[*]Permission: [I]databridge.admin.reload[/I]
+[*]Permission: [I]databridge.admin[/I]
 [/LIST]
 [/LIST]
 
@@ -76,6 +88,13 @@ MC Data Bridge is a robust, high-performance hybrid synchronization suite for [B
 [LIST]
 [*][B]/databridge unlock <player>[/B] (Bungee/Velocity): Releases a lock across the network.
 [*][B]/databridge forceunlock <player>[/B] (Bungee/Velocity): Relays a signal to the backend server to drop the lock immediately.
+[/LIST]
+
+[SIZE=4][B]Permission Nodes:[/B][/SIZE]
+[LIST]
+[*][B]databridge.inspect[/B]: Permission to view player data, inventories, and ender chests in safe read-only mode.
+[*][B]databridge.inspect.edit[/B]: Elevated permission required to interactively edit inventories and ender chests via [I]--edit[/I] or Right-Click.
+[*][B]databridge.admin[/B]: Master administrative access for all commands and functions.
 [/LIST]
 
 [SIZE=5]► Links & Support[/SIZE]

--- a/DESCRIPTION.md
+++ b/DESCRIPTION.md
@@ -22,7 +22,12 @@ This plugin is a hybrid build and the same JAR file works on all supported platf
 - **Industrial Identity Protection:** Tracks `last_known_name` and secure identity hashes to prevent identity hijacking and manage UUID transitions in hybrid (Cracked/Premium) environments.
 - **Zero-Tick Identity Verification:** Database locks and identity checks are performed during the `AsyncPlayerPreLoginEvent`, ensuring that player state is verified and ready before they even reach the server's "Join" state.
 - **Regionalized Folia Support:** Built with `SchedulerUtils` to handle regionalized threading, ensuring safe execution on Folia's multi-threaded clusters.
-- **Administrative Inspector GUI:** A visual interface for administrators to inspect saved player data (inventories, stats, PDC) even when the player is offline.
+- **Interactive Inventory & Ender Chest Inspector (`invsee` / `endersee`):**
+  - **Overview GUI Controls:** **Left-Click** inventory or ender chest icons to view in Safe Read-Only Mode (`databridge.inspect`); **Right-Click** icons to open in Interactive Edit Mode (`databridge.inspect.edit`).
+  - **Safe View-Only Mode (Default):** View player inventory and ender chest snapshots in read-only mode (`databridge.inspect`).
+  - **Interactive Edit Mode (`--edit` flag or Right-Click):** Admins with elevated permissions (`databridge.inspect.edit`) can interactively modify offline or cross-server player inventories with automatic database synchronization on GUI close.
+- **Full Command Tab Completion:** Comprehensive auto-completion for subcommands, player names, view options, and flags.
+- **Administrative Inspector GUI:** Visual interface for administrators to inspect saved player data (inventories, stats, PDC) even when the player is offline.
 - **Proxy-Initiated Saves:** The proxy (BungeeCord/Velocity) orchestrates the data saving process, ensuring that a player's data is saved from their source server _before_ they connect to the destination server. This eliminates race conditions.
 - **Fully Asynchronous:** All database and serialization operations are performed on a separate thread, ensuring that your server's main thread is never blocked.
 - **Robust Locking Mechanism:** A database-level locking mechanism with an automatic timeout and heartbeats prevents data corruption.
@@ -56,17 +61,25 @@ This plugin is a hybrid build and the same JAR file works on all supported platf
 
 ## Commands & Permissions
 
-| Command                            | Description                                | Permission                 |
-| :--------------------------------- | :----------------------------------------- | :------------------------- |
-| `/databridge inspect <player>`     | Opens a GUI to view offline player data.   | `databridge.admin.inspect` |
-| `/databridge migrate <src> <dest>` | Securely move data between two identities. | `databridge.admin.migrate` |
-| `/databridge unlock <player>`      | Manually release a stuck data lock.        | `databridge.admin.unlock`  |
-| `/databridge reload`               | Reloads the configuration and DB pool.     | `databridge.admin.reload`  |
+| Command                                                         | Description                                               | Permission                                                       |
+| :-------------------------------------------------------------- | :-------------------------------------------------------- | :--------------------------------------------------------------- |
+| `/databridge inspect <player> [inventory\|enderchest] [--edit]` | Opens GUI to view or edit saved player data/inventory.    | `databridge.inspect`<br>`databridge.inspect.edit` (for `--edit`) |
+| `/databridge invsee <player> [--edit]`                          | Directly opens saved player inventory view or edit GUI.   | `databridge.inspect`<br>`databridge.inspect.edit` (for `--edit`) |
+| `/databridge endersee <player> [--edit]`                        | Directly opens saved player ender chest view or edit GUI. | `databridge.inspect`<br>`databridge.inspect.edit` (for `--edit`) |
+| `/databridge migrate <src> <dest>`                              | Securely move data between two identities.                | `databridge.admin`                                               |
+| `/databridge unlock <player>`                                   | Manually release a stuck data lock.                       | `databridge.admin`                                               |
+| `/databridge reload`                                            | Reloads configuration and reconnects to database pool.     | `databridge.admin`                                               |
 
 **Proxy Commands:**
 
-- `/databridge unlock <player>` (Bungee/Velocity): Releases a lock across the network.
-- `/databridge forceunlock <player>` (Bungee/Velocity): Relays a signal to the backend server to drop the lock immediately.
+- `/databridge unlock <player>` (Bungee/Velocity): Relays a signal to the backend Spigot server to release the lock across the network.
+- `/databridge forceunlock <player>` (Bungee/Velocity): Relays an immediate signal to the backend server to drop the lock.
+
+**Permission Nodes:**
+
+- `databridge.inspect` - Permission to view player data, inventories, and ender chests in safe read-only mode.
+- `databridge.inspect.edit` - Elevated permission required to interactively edit inventories and ender chests via `--edit` or Right-Click.
+- `databridge.admin` - Master administrative access (includes unlock, migrate, reload, forceunlock, inspect, edit).
 
 ## Configuration
 
@@ -187,7 +200,7 @@ In addition to the primary tracking table (`player_data`), MC Data Bridge uses c
 ### Statistics Component: `databridge_statistics`
 
 - Holds basic stats (`health` DOUBLE/REAL, `food_level` INT/INTEGER, `xp_level` INT/INTEGER, `xp_exp` FLOAT/REAL, `xp_total` INT/INTEGER, `saturation` FLOAT/REAL, `exhaustion` FLOAT/REAL).
-- Holds `vanilla_stats_json` (LONGTEXT/TEXT) containing dynamic statistics, locations, and recipe states.
+- Holds `vanilla_stats_json` (TEXT) containing dynamic statistics, locations, and recipe states.
 - Includes a `last_updated` auto-timestamp.
 
 ### Metadata Component: `databridge_metadata`

--- a/DOCUMENTATION.bbcode
+++ b/DOCUMENTATION.bbcode
@@ -57,33 +57,51 @@ Below is a detailed explanation of the [I]config.yml[/I] settings. This file is 
 
 [SIZE=4][B]Administrator Commands[/B][/SIZE]
 [LIST]
-[*][B]/databridge inspect <player>[/B]
+[*][B]/databridge inspect <player> [inventory|enderchest] [--edit][/B]
 [LIST]
-[*]Opens a GUI to view the saved stats and inventory of a player.
+[*]Opens GUI to view or edit saved player data, inventory, or ender chest.
+[*]Left-Click items to view in Safe Read-Only Mode; Right-Click items to open in Interactive Edit Mode.
 [*]Works even if the player is offline.
-[*]Permission: [I]databridge.admin.inspect[/I]
+[*]Permission: [I]databridge.inspect[/I] / [I]databridge.inspect.edit[/I] (for [I]--edit[/I] or Right-Click)
+[/LIST]
+[*][B]/databridge invsee <player> [--edit][/B]
+[LIST]
+[*]Directly opens saved player inventory view or edit GUI.
+[*]Permission: [I]databridge.inspect[/I] / [I]databridge.inspect.edit[/I] (for [I]--edit[/I])
+[/LIST]
+[*][B]/databridge endersee <player> [--edit][/B]
+[LIST]
+[*]Directly opens saved player ender chest view or edit GUI.
+[*]Permission: [I]databridge.inspect[/I] / [I]databridge.inspect.edit[/I] (for [I]--edit[/I])
 [/LIST]
 [*][B]/databridge migrate <source> <target>[/B]
 [LIST]
 [*]Manually move data between two identities (UUID or Name).
-[*]Permission: [I]databridge.admin.migrate[/I]
+[*]Permission: [I]databridge.admin[/I]
 [/LIST]
 [*][B]/databridge unlock <player>[/B]
 [LIST]
 [*]Releases a stuck data lock if a server crashed without releasing it.
-[*]Permission: [I]databridge.admin.unlock[/I]
+[*]Permission: [I]databridge.admin[/I]
 [/LIST]
 [*][B]/databridge reload[/B]
 [LIST]
-[*]Reloads the configuration and reconnects to the database.
-[*]Permission: [I]databridge.admin.reload[/I]
+[*]Reloads the configuration and reconnects to the database pool.
+[*]Permission: [I]databridge.admin[/I]
 [/LIST]
 [/LIST]
 
 [SIZE=4][B]Proxy Commands[/B][/SIZE]
 [LIST]
-[*][B]/databridge unlock <player>[/B] (Available on Bungee/Velocity)
-[*][B]/databridge forceunlock <player>[/B] (Relays a signal to the backend server to drop the lock immediately)
+[*][B]/databridge unlock <player>[/B] (Available on Bungee/Velocity): Releases a data lock across the network.
+[*][B]/databridge forceunlock <player>[/B] (Available on Bungee/Velocity): Relays a signal to the backend server to drop the lock immediately.
+[/LIST]
+
+[SIZE=4][B]Permission Nodes Breakdown[/B][/SIZE]
+[LIST]
+[*][B]databridge.inspect[/B]: Permission to view player data, inventories, and ender chests in safe read-only mode.
+[*][B]databridge.inspect.edit[/B]: Elevated permission required to interactively edit inventories and ender chests via [I]--edit[/I] or Right-Click.
+[*][B]databridge.admin[/B]: Full administrative access (includes unlock, migrate, reload, forceunlock, inspect, edit).
 [/LIST]
 
 [SIZE=5]► Database Schema Information[/SIZE]

--- a/README.md
+++ b/README.md
@@ -19,6 +19,13 @@ This plugin is a hybrid build and the same JAR file works on all supported platf
 
 ## Features
 
+- **Item Duplication Exploit Protection:** Automatically closes open inventory views during server transfer and cancels container clicks, drags, item drops, pickups, and interactions while transfer locks are held.
+- **Interactive Inventory & Ender Chest Inspector (`invsee` / `endersee`):** Inspect offline or cross-server player inventories and ender chests.
+  - **Overview GUI Controls:** **Left-Click** inventory or ender chest icons to view in Safe Read-Only Mode; **Right-Click** icons to open in Interactive Edit Mode (gated by permission).
+  - **Safe View-Only Mode (Default):** Opens in read-only mode to prevent accidental item modifications.
+  - **Interactive Edit Mode (`--edit` flag or Right-Click):** Admins with `databridge.inspect.edit` permission can edit offline/cross-server player items directly in the GUI with automatic database persistence upon closing.
+- **Full Command Tab Completion:** Comprehensive auto-completion for subcommands, player names, view options, and flags.
+- **Auto-Schema Maintenance:** Toggle `auto-update-schema` (default `true`) for automated table maintenance and column upgrades (`LONGTEXT` support for large stats and metadata).
 - **Hybrid Plugin:** A single JAR file works on your PaperMC/Purpur/Spigot/Folia servers and your BungeeCord/Waterfall/Velocity proxy, automatically activating the correct functionality for each platform.
 - **Identity History Tracking:** Automatically tracks `last_known_name` and a secure `identity_hash` (SHA-256) to enable secure UUID change detection and prevent identity hijacking in hybrid (Cracked/Premium) environments.
 - **Identity Modes (PREMIUM/HYBRID):** Toggle between strict UUID enforcement for premium servers or flexible identity shifts for hybrid/cracked networks.
@@ -296,12 +303,22 @@ sync-blacklist:
 
 MC Data Bridge uses a consolidated command hub for all administrative tasks.
 
-- `/databridge unlock <player>` - Manually release a data lock. Works on Spigot, Folia, Bungee, and Velocity.
-- `/databridge inspect <player>` - Open a visual GUI to inspect a player's saved data (Paper/Spigot/Folia only).
+- `/databridge inspect <player> [inventory|enderchest] [--edit]` - Open a visual GUI to inspect or edit a player's saved data and inventory.
+- `/databridge invsee <player> [--edit]` - Directly open a player's saved inventory view or edit GUI.
+- `/databridge endersee <player> [--edit]` - Directly open a player's saved ender chest view or edit GUI.
+- `/databridge unlock <player>` - Manually release a stuck data lock. Works on Spigot, Folia, Bungee, and Velocity.
 - `/databridge migrate <source> <target>` - Securely migrate data from one player (UUID or Name) to another. Useful for account recoveries or identity changes.
+- `/databridge reload` - Reload plugin configuration and database connection pool.
 
-**Aliases:** `/db`
-**Permission:** `databridge.admin`
+**Proxy Commands:**
+- `/databridge unlock <player>` - Network-wide data lock release.
+- `/databridge forceunlock <player>` - Relays immediate lock drop signal to backend server.
+
+**Aliases:** `/db`  
+**Permissions:**
+- `databridge.inspect` - Permission to view player data, inventories, and ender chests in safe read-only mode.
+- `databridge.inspect.edit` - Elevated permission required to interactively edit inventories/ender chests via `--edit`.
+- `databridge.admin` - Full administrative access (includes unlock, migrate, reload, forceunlock, inspect, edit).
 
 ## Usage
 

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.digitalserverhost.plugins</groupId>
     <artifactId>mc-data-bridge</artifactId>
-    <version>2.1.7-SNAPSHOT</version>
+    <version>2.1.8</version>
 
     <name>mc-data-bridge</name>
     <url>https://mc.digitalserverhost.com</url>
@@ -37,7 +37,7 @@
         <dependency>
             <groupId>io.papermc.paper</groupId>
             <artifactId>paper-api</artifactId>
-            <version>26.1.2.build.69-stable</version>
+            <version>26.2.build.25-alpha</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
@@ -56,24 +56,24 @@
         <dependency>
             <groupId>com.zaxxer</groupId>
             <artifactId>HikariCP</artifactId>
-            <version>7.0.2</version>
+            <version>7.1.0</version>
         </dependency>
         <dependency>
             <groupId>net.kyori</groupId>
             <artifactId>adventure-api</artifactId>
-            <version>4.26.1</version>
+            <version>5.1.1</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>net.kyori</groupId>
             <artifactId>adventure-text-serializer-legacy</artifactId>
-            <version>4.26.1</version>
+            <version>5.1.1</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>net.kyori</groupId>
             <artifactId>adventure-text-minimessage</artifactId>
-            <version>4.26.1</version>
+            <version>5.1.1</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
@@ -118,6 +118,12 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>io.github.secondlifegaming</groupId>
+            <artifactId>mockmc-v26.2</artifactId>
+            <version>0.0.5</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>fr.xephi</groupId>
             <artifactId>authme</artifactId>
             <version>5.7.0</version>
@@ -125,40 +131,6 @@
         </dependency>
     </dependencies>
     
-    <profiles>
-        <profile>
-            <id>local-dev</id>
-            <activation>
-                <property>
-                    <name>!env.GITHUB_ACTIONS</name>
-                </property>
-            </activation>
-            <dependencies>
-                <dependency>
-                    <groupId>io.github.secondlifegaming</groupId>
-                    <artifactId>mockmc-v26.1</artifactId>
-                    <version>dev-dee37368b</version>
-                    <scope>test</scope>
-                </dependency>
-            </dependencies>
-        </profile>
-        <profile>
-            <id>github-ci</id>
-            <activation>
-                <property>
-                    <name>env.GITHUB_ACTIONS</name>
-                </property>
-            </activation>
-            <dependencies>
-                <dependency>
-                    <groupId>org.mockbukkit.mockbukkit</groupId>
-                    <artifactId>mockbukkit-v1.21</artifactId>
-                    <version>4.108.0</version>
-                    <scope>test</scope>
-                </dependency>
-            </dependencies>
-        </profile>
-    </profiles>
 
     <build>
         <plugins>

--- a/release-notes.bbcode
+++ b/release-notes.bbcode
@@ -1,18 +1,54 @@
-[SIZE=6][B]MC Data Bridge - Release Notes (v2.1.7)[/B][/SIZE]
+[SIZE=6][B]MC Data Bridge - Release Notes (v2.1.8)[/B][/SIZE]
 
 [SIZE=5][B]Overview[/B][/SIZE]
-[SIZE=4]Version 2.1.7 is a targeted bugfix release that upgrades the [B]vanilla_stats_json[/B] column type in the statistics component table to [B]LONGTEXT[/B] (for MySQL/MariaDB), preventing potential data truncation issues when synchronizing large volumes of vanilla player statistics. It also introduces automatic schema migration for existing databases.[/SIZE]
+[SIZE=4]Version 2.1.8 introduces [B]Item Duplication Exploit Protection[/B], [B]Full Tab Completion[/B], [B]Interactive Inventory & Ender Chest Inspection (`invsee` & `endersee`)[/B] with read-only and edit modes, [B]Granular Permissions[/B], [B]Database Schema Auto-Migration[/B], and [B]Paper 26.2 Platform Parity[/B].[/SIZE]
 
 [CENTER]----------------------------------------------------------------[/CENTER]
 
-[SIZE=5][B]Changes in v2.1.7[/B][/SIZE]
+[SIZE=5][B]Key Changes[/B][/SIZE]
 
-[SIZE=4][B]🗄️ Database Schema Upgrade & Migration[/B][/SIZE]
+[SIZE=4][B]🛡 Item Duplication Exploit Protection (#30)[/B][/SIZE]
 [LIST]
-[*][B]Upgrade to LONGTEXT:[/B] Upgraded the [I]vanilla_stats_json[/I] column from [I]TEXT[/I] to [I]LONGTEXT[/I] in the [I]databridge_statistics[/I] table to support larger JSON payloads without risk of truncation.
-[*][B]Automated Migration:[/B] Added support for automatically executing the [CODE]ALTER TABLE ... MODIFY COLUMN ...[/CODE] statement when [CODE]auto-update-schema[/CODE] is set to [CODE]true[/CODE] in the configuration.
-[*][B]Admin Warning Notice:[/B] If [CODE]auto-update-schema[/CODE] is disabled, the plugin will now log a prominent warning suggesting the manual execution of the schema migration command:
-[CODE]ALTER TABLE `table_prefix_databridge_statistics` MODIFY COLUMN vanilla_stats_json LONGTEXT DEFAULT NULL;[/CODE]
+[*][B]Special Thanks:[/B] Special thanks to [B]@AllenLinong[/B] for discovering and reporting this critical exploit (#30)!
+[*][B]Safe Inventory Closure:[/B] Open inventory views are automatically closed before player data snapshots are captured during server switches.
+[*][B]Transfer Lock Enforcement:[/B] Cancels item drops, item pickups, container clicks, inventory drags, and interactions while a player transfer or database save is in progress.
+[/LIST]
+
+[SIZE=4][B]🔍 Interactive Inventory & Ender Chest Inspector (`invsee` / `endersee`)[/B][/SIZE]
+[LIST]
+[*][B]New Subcommands & Aliases:[/B]
+[LIST]
+[*][CODE]/databridge inspect <player> [inventory|enderchest] [--edit][/CODE]
+[*][CODE]/databridge invsee <player> [--edit][/CODE]
+[*][CODE]/databridge endersee <player> [--edit][/CODE]
+[/LIST]
+[*][B]Safe View-Only Mode (Default):[/B] Inspection GUIs open in read-only mode by default ([I]Left-Click[/I] in Overview GUI) to prevent accidental item modifications or unintended edits.
+[*][B]Interactive Edit Mode ([I]--edit[/I] flag or Right-Click):[/B] Admins with [I]databridge.inspect.edit[/I] permission can interactively edit items ([I]Right-Click[/I] in Overview GUI or using [I]--edit[/I] flag) in offline/cross-server player inventories or ender chests directly inside the GUI.
+[*][B]Database Auto-Save:[/B] Closing an editable GUI automatically serializes modified item stacks back to the database so changes apply when the player logs in.
+[/LIST]
+
+[SIZE=4][B]🔑 Granular Permission Nodes[/B][/SIZE]
+[LIST]
+[*][CODE]databridge.inspect[/CODE] (or [I]databridge.admin[/I]): Permission to view player data, inventories, and ender chests in safe read-only mode.
+[*][CODE]databridge.inspect.edit[/CODE] (or [I]databridge.admin[/I]): Elevated permission required to open interactive edit mode using the [I]--edit[/I] flag.
+[*][CODE]databridge.admin[/CODE]: Full administrative access to all commands and subcommands.
+[/LIST]
+
+[SIZE=4][B]⌨️ Full Command Tab Completion[/B][/SIZE]
+[LIST]
+[*][B]TabExecutor Integration:[/B] Dynamic auto-completion for subcommands ([I]unlock[/I], [I]inspect[/I], [I]invsee[/I], [I]endersee[/I], [I]migrate[/I]), online player names, view types ([I]inventory[/I], [I]enderchest[/I]), and the [I]--edit[/I] flag.
+[/LIST]
+
+[SIZE=4][B]🗄 Database Schema Maintenance & Upgrades[/B][/SIZE]
+[LIST]
+[*][B]Auto-Update Schema:[/B] Added [I]auto-update-schema[/I] configuration toggle (default [I]true[/I]) to automatically manage table upgrades.
+[*][B]Column Expansion:[/B] Upgraded [I]vanilla_stats_json[/I] column to [I]LONGTEXT[/I] (MySQL/MariaDB) / [I]TEXT[/I] (SQLite) to accommodate large recipe books, advancements, and vanilla statistics.
+[/LIST]
+
+[SIZE=4][B]⚡ Paper 26.2 & Dependency Upgrades[/B][/SIZE]
+[LIST]
+[*][B]HikariCP:[/B] Upgraded connection pool library to [I]7.1.0[/I].
+[*][B]Paper API:[/B] Upgraded compiling API target to [I]26.2[/I] while retaining full backward compatibility for pre-26.2 versions via platform reflection.
 [/LIST]
 
 [CENTER]----------------------------------------------------------------[/CENTER]

--- a/release-notes.md
+++ b/release-notes.md
@@ -1,21 +1,49 @@
-# MC Data Bridge - Release Notes (v2.1.7)
+# MC Data Bridge - Release Notes (v2.1.8)
 
 ## Overview
 
-Version 2.1.7 is a targeted bugfix release that upgrades the `vanilla_stats_json` column type in the statistics component table to `LONGTEXT` (for MySQL/MariaDB), preventing potential data truncation issues when synchronizing large volumes of vanilla player statistics. It also introduces automatic schema migration for existing databases.
+Version 2.1.8 introduces **Item Duplication Exploit Protection**, **Full Tab Completion**, **Interactive Inventory & Ender Chest Inspection (`invsee` & `endersee`)** with read-only and edit modes, **Granular Permissions**, **Database Schema Auto-Migration**, and **Paper 26.2 Platform Parity**.
 
 ---
 
-## Changes in v2.1.7
+## Key Changes
 
-### 🗄️ Database Schema Upgrade & Migration
+### 🛡 Item Duplication Exploit Protection (#30)
 
-- **Upgrade to LONGTEXT:** Upgraded the `vanilla_stats_json` column from `TEXT` to `LONGTEXT` in the `databridge_statistics` table to support larger JSON payloads without risk of truncation.
-- **Automated Migration:** Added support for automatically executing the `ALTER TABLE ... MODIFY COLUMN ...` statement when `auto-update-schema` is set to `true` in the configuration.
-- **Admin Warning Notice:** If `auto-update-schema` is disabled, the plugin will now log a prominent warning suggesting the manual execution of the schema migration command:
-  ```sql
-  ALTER TABLE `table_prefix_databridge_statistics` MODIFY COLUMN vanilla_stats_json LONGTEXT DEFAULT NULL;
-  ```
+- **Special Thanks:** Special thanks to **@AllenLinong** for discovering and reporting this critical exploit ([#30](https://github.com/westkevin12/mc-data-bridge/issues/30))!
+- **Safe Inventory Closure:** Open inventory views are automatically closed before player data snapshots are captured during server switches.
+- **Transfer Lock Enforcement:** Cancels item drops, item pickups, container clicks, inventory drags, and block/entity interactions while a player transfer or database save is in progress.
+
+### 🔍 Interactive Inventory & Ender Chest Inspector (`invsee` / `endersee`)
+
+- **New Subcommands & Aliases:**
+  - `/databridge inspect <player> [inventory|enderchest] [--edit]`
+  - `/databridge invsee <player> [--edit]`
+  - `/databridge endersee <player> [--edit]`
+- **Safe View-Only Mode (Default):** Inspection GUIs open in read-only mode by default (**Left-Click** in Overview GUI) to prevent accidental item modifications or unintended edits.
+- **Interactive Edit Mode (`--edit` flag or Right-Click):** Admins with `databridge.inspect.edit` permission can interactively edit items (**Right-Click** in Overview GUI or using `--edit` flag) in offline/cross-server player inventories or ender chests directly inside the GUI.
+- **Database Auto-Save:** Closing an editable GUI (`InventoryCloseEvent`) automatically serializes modified item stacks back to the database so changes apply when the player logs in.
+
+### 🔑 Granular Permission Nodes
+
+- `databridge.inspect` (or `databridge.admin`): Permission to view player data, inventories, and ender chests in safe read-only mode.
+- `databridge.inspect.edit` (or `databridge.admin`): Elevated permission required to open interactive edit mode using the `--edit` flag.
+- `databridge.admin`: Full administrative access to all commands and subcommands.
+
+### ⌨️ Full Command Tab Completion
+
+- **TabExecutor / Brigadier Integration:** Added dynamic auto-completion for subcommands (`unlock`, `inspect`, `invsee`, `endersee`, `migrate`), online player names, view types (`inventory`, `enderchest`), and the `--edit` flag.
+
+### 🗄 Database Schema Maintenance & Upgrades
+
+- **Auto-Update Schema:** Added `auto-update-schema` configuration toggle (default `true`) to automatically manage table upgrades.
+- **Column Expansion:** Upgraded `vanilla_stats_json` column to `LONGTEXT` (MySQL/MariaDB) / `TEXT` (SQLite) to accommodate large recipe books, advancements, and vanilla statistics.
+
+### ⚡ Paper 26.2 & Dependency Upgrades
+
+- **Updated Target API:** Compiled and tested against Paper API `26.2` and verified on Paper 26.2+ servers.
+- **HikariCP:** Upgraded connection pool library to `7.1.0`.
+- **Platform Reflection:** Retains full backward compatibility for pre-26.2 Spigot/Paper versions via dynamic reflection.
 
 ---
 

--- a/src/main/java/com/digitalserverhost/plugins/MCDataBridge.java
+++ b/src/main/java/com/digitalserverhost/plugins/MCDataBridge.java
@@ -46,15 +46,15 @@ public class MCDataBridge extends JavaPlugin {
     }
 
     private static final java.util.Map<String, java.util.Map.Entry<String, String>> COLUMN_WHITELIST = java.util.Map.of(
-        "is_locked", java.util.Map.entry("BOOLEAN DEFAULT 0", INTEGER_DEFAULT_0),
-        "locking_server", java.util.Map.entry("VARCHAR(255) DEFAULT NULL", TEXT_DEFAULT_NULL),
-        "lock_timestamp", java.util.Map.entry(BIGINT_DEFAULT_0, INTEGER_DEFAULT_0),
-        "last_known_name", java.util.Map.entry("VARCHAR(16) DEFAULT NULL", TEXT_DEFAULT_NULL),
-        "data_checksum", java.util.Map.entry(VARCHAR64_DEFAULT_NULL, TEXT_DEFAULT_NULL),
-        "identity_hash", java.util.Map.entry(VARCHAR64_DEFAULT_NULL, TEXT_DEFAULT_NULL),
-        "name_last_updated", java.util.Map.entry(BIGINT_DEFAULT_0, INTEGER_DEFAULT_0),
-        "last_updated", java.util.Map.entry("TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP", "DATETIME DEFAULT CURRENT_TIMESTAMP")
-    );
+            "is_locked", java.util.Map.entry("BOOLEAN DEFAULT 0", INTEGER_DEFAULT_0),
+            "locking_server", java.util.Map.entry("VARCHAR(255) DEFAULT NULL", TEXT_DEFAULT_NULL),
+            "lock_timestamp", java.util.Map.entry(BIGINT_DEFAULT_0, INTEGER_DEFAULT_0),
+            "last_known_name", java.util.Map.entry("VARCHAR(16) DEFAULT NULL", TEXT_DEFAULT_NULL),
+            "data_checksum", java.util.Map.entry(VARCHAR64_DEFAULT_NULL, TEXT_DEFAULT_NULL),
+            "identity_hash", java.util.Map.entry(VARCHAR64_DEFAULT_NULL, TEXT_DEFAULT_NULL),
+            "name_last_updated", java.util.Map.entry(BIGINT_DEFAULT_0, INTEGER_DEFAULT_0),
+            "last_updated", java.util.Map.entry("TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP",
+                    "DATETIME DEFAULT CURRENT_TIMESTAMP"));
 
     private void startSpigot() {
         saveDefaultConfig();
@@ -78,7 +78,7 @@ public class MCDataBridge extends JavaPlugin {
             getLogger().warning("!!! This is UNSAFE for multi-server setups.           !!!");
             getLogger().warning(BANNER);
         }
-        
+
         this.securitySeed = getConfig().getString("security.seed", DEFAULT_SEED);
         if (this.securitySeed == null || this.securitySeed.isEmpty() || this.securitySeed.equals(DEFAULT_SEED)) {
             String envSeed = System.getenv("DATABRIDGE_SEED");
@@ -101,17 +101,18 @@ public class MCDataBridge extends JavaPlugin {
         this.autoMigrateFastLogin = getConfig().getBoolean("identity.auto-migrate-fastlogin", false);
         this.autoMigrateAuthMe = getConfig().getBoolean("identity.auto-migrate-authme", false);
         databaseManager = new DatabaseManager(getConfig(), this.tableName);
-        
+
         // Initialize Metrics Exporter if enabled
         if (getConfig().getBoolean("metrics.enabled", false)) {
             int metricsPort = getConfig().getInt("metrics.port", 8080);
             String metricsPath = getConfig().getString("metrics.path", "/metrics");
-            com.digitalserverhost.plugins.managers.MetricsManager.getInstance().start(this, databaseManager, metricsPort, metricsPath);
+            com.digitalserverhost.plugins.managers.MetricsManager.getInstance().start(this, databaseManager,
+                    metricsPort, metricsPath);
         }
 
         // Ensure table and columns exist synchronously before events are registered
         createServerTable();
-        
+
         com.digitalserverhost.plugins.utils.SchedulerUtils.runAsync(this, this::releaseOrphanedLocks);
 
         // Create the listener instance
@@ -122,13 +123,20 @@ public class MCDataBridge extends JavaPlugin {
 
         // Register AuthMe auto-migration listener if enabled
         if (getServer().getPluginManager().isPluginEnabled("AuthMe")) {
-            getServer().getPluginManager().registerEvents(new com.digitalserverhost.plugins.listeners.AuthMeListener(this, databaseManager), this);
+            getServer().getPluginManager().registerEvents(
+                    new com.digitalserverhost.plugins.listeners.AuthMeListener(this, databaseManager), this);
             getLogger().info("AuthMe integration enabled for auto-migration.");
         }
 
+        // Initialize GUI Manager and register GUI click listener
+        com.digitalserverhost.plugins.utils.DataManagementGUI guiManager = new com.digitalserverhost.plugins.utils.DataManagementGUI(this, databaseManager);
+        getServer().getPluginManager().registerEvents(guiManager, this);
+
         org.bukkit.command.PluginCommand cmd = getCommand("databridge");
         if (cmd != null) {
-            cmd.setExecutor(new com.digitalserverhost.plugins.commands.BridgeCommand(databaseManager));
+            com.digitalserverhost.plugins.commands.BridgeCommand bridgeCmd = new com.digitalserverhost.plugins.commands.BridgeCommand(databaseManager, guiManager);
+            cmd.setExecutor(bridgeCmd);
+            cmd.setTabCompleter(bridgeCmd);
         }
 
         // Register it as the listener for our custom plugin channel
@@ -166,22 +174,31 @@ public class MCDataBridge extends JavaPlugin {
                 Statement statement = connection.createStatement()) {
 
             migrateFromLegacyTable(connection, statement, escapedTableName);
-            
+
             String createTableSQL = getCreateTableSQL(dbType, escapedTableName);
             statement.executeUpdate(createTableSQL);
             getLogger().log(java.util.logging.Level.INFO, "Successfully verified or created the {0} table.", tableName);
 
-            ensureColumnExists(connection, statement, escapedTableName, dbType, "is_locked", "BOOLEAN DEFAULT 0", INTEGER_DEFAULT_0);
-            ensureColumnExists(connection, statement, escapedTableName, dbType, "locking_server", "VARCHAR(255) DEFAULT NULL", TEXT_DEFAULT_NULL);
-            ensureColumnExists(connection, statement, escapedTableName, dbType, "lock_timestamp", BIGINT_DEFAULT_0, INTEGER_DEFAULT_0);
-            ensureColumnExists(connection, statement, escapedTableName, dbType, "last_known_name", "VARCHAR(16) DEFAULT NULL", TEXT_DEFAULT_NULL);
-            ensureColumnExists(connection, statement, escapedTableName, dbType, "data_checksum", VARCHAR64_DEFAULT_NULL, TEXT_DEFAULT_NULL);
-            ensureColumnExists(connection, statement, escapedTableName, dbType, "identity_hash", VARCHAR64_DEFAULT_NULL, TEXT_DEFAULT_NULL);
-            ensureColumnExists(connection, statement, escapedTableName, dbType, "name_last_updated", BIGINT_DEFAULT_0, INTEGER_DEFAULT_0);
-            ensureColumnExists(connection, statement, escapedTableName, dbType, "last_updated", "TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP", "DATETIME DEFAULT CURRENT_TIMESTAMP");
+            ensureColumnExists(connection, statement, escapedTableName, dbType, "is_locked", "BOOLEAN DEFAULT 0",
+                    INTEGER_DEFAULT_0);
+            ensureColumnExists(connection, statement, escapedTableName, dbType, "locking_server",
+                    "VARCHAR(255) DEFAULT NULL", TEXT_DEFAULT_NULL);
+            ensureColumnExists(connection, statement, escapedTableName, dbType, "lock_timestamp", BIGINT_DEFAULT_0,
+                    INTEGER_DEFAULT_0);
+            ensureColumnExists(connection, statement, escapedTableName, dbType, "last_known_name",
+                    "VARCHAR(16) DEFAULT NULL", TEXT_DEFAULT_NULL);
+            ensureColumnExists(connection, statement, escapedTableName, dbType, "data_checksum", VARCHAR64_DEFAULT_NULL,
+                    TEXT_DEFAULT_NULL);
+            ensureColumnExists(connection, statement, escapedTableName, dbType, "identity_hash", VARCHAR64_DEFAULT_NULL,
+                    TEXT_DEFAULT_NULL);
+            ensureColumnExists(connection, statement, escapedTableName, dbType, "name_last_updated", BIGINT_DEFAULT_0,
+                    INTEGER_DEFAULT_0);
+            ensureColumnExists(connection, statement, escapedTableName, dbType, "last_updated",
+                    "TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP",
+                    "DATETIME DEFAULT CURRENT_TIMESTAMP");
 
             migrateDataColumn(connection, statement, escapedTableName, dbType);
-            
+
             // Create component tables for normalized schema
             String tablePrefix = getConfig().getString(CONFIG_TABLE_PREFIX, "");
             String escapedInventories = "`" + tablePrefix + "databridge_inventories`";
@@ -248,11 +265,12 @@ public class MCDataBridge extends JavaPlugin {
                         "last_updated TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP, " +
                         "PRIMARY KEY (uuid)) ENGINE=InnoDB;");
             }
-            
+
             migrateStatisticsColumn(connection, statement, dbType);
-            
+
         } catch (Exception e) {
-            getLogger().log(java.util.logging.Level.SEVERE, "CRITICAL: Error creating or updating player_data table: {0}", e.getMessage());
+            getLogger().log(java.util.logging.Level.SEVERE,
+                    "CRITICAL: Error creating or updating player_data table: {0}", e.getMessage());
             getServer().getPluginManager().disablePlugin(this);
         }
     }
@@ -286,7 +304,8 @@ public class MCDataBridge extends JavaPlugin {
         }
     }
 
-    private void migrateFromLegacyTable(Connection connection, Statement statement, String escapedTableName) throws SQLException {
+    private void migrateFromLegacyTable(Connection connection, Statement statement, String escapedTableName)
+            throws SQLException {
         if (!tableName.equals(DEFAULT_TABLE_NAME)) {
             try {
                 ResultSet oldTable = connection.getMetaData().getTables(null, null, DEFAULT_TABLE_NAME, null);
@@ -308,8 +327,8 @@ public class MCDataBridge extends JavaPlugin {
         }
     }
 
-    private void ensureColumnExists(Connection connection, Statement statement, String escapedTableName, String dbType, 
-                                  String column, String mysqlType, String sqliteType) throws SQLException {
+    private void ensureColumnExists(Connection connection, Statement statement, String escapedTableName, String dbType,
+            String column, String mysqlType, String sqliteType) throws SQLException {
         java.util.Map.Entry<String, String> allowedTypes = COLUMN_WHITELIST.get(column);
         if (allowedTypes == null) {
             throw new SecurityException("Blocked attempt to add un-whitelisted column: " + column);
@@ -324,7 +343,8 @@ public class MCDataBridge extends JavaPlugin {
         }
     }
 
-    private void migrateDataColumn(Connection connection, Statement statement, String escapedTableName, String dbType) throws SQLException {
+    private void migrateDataColumn(Connection connection, Statement statement, String escapedTableName, String dbType)
+            throws SQLException {
         try (ResultSet columns = connection.getMetaData().getColumns(null, null, tableName, "data")) {
             if (columns.next()) {
                 String typeName = columns.getString("TYPE_NAME");
@@ -332,12 +352,16 @@ public class MCDataBridge extends JavaPlugin {
 
                 if (needsMigration) {
                     if (getConfig().getBoolean(AUTO_UPDATE_SCHEMA, false)) {
-                        if (dbType.equals(SQLITE)) return;
-                        getLogger().log(java.util.logging.Level.INFO, "Migrating 'data' column from {0} to LONGBLOB as requested...", typeName);
-                        statement.executeUpdate(ALTER_TABLE_SQL + escapedTableName + " MODIFY COLUMN data LONGBLOB NULL");
+                        if (dbType.equals(SQLITE))
+                            return;
+                        getLogger().log(java.util.logging.Level.INFO,
+                                "Migrating 'data' column from {0} to LONGBLOB as requested...", typeName);
+                        statement.executeUpdate(
+                                ALTER_TABLE_SQL + escapedTableName + " MODIFY COLUMN data LONGBLOB NULL");
                     } else {
                         getLogger().warning(BANNER);
-                        getLogger().log(java.util.logging.Level.WARNING, "!!! YOUR DATABASE IS USING {0} FOR 'data' COLUMN. !!!", typeName);
+                        getLogger().log(java.util.logging.Level.WARNING,
+                                "!!! YOUR DATABASE IS USING {0} FOR 'data' COLUMN. !!!", typeName);
                         getLogger().warning("!!! IT IS RECOMMENDED TO SWITCH TO 'LONGBLOB' !!!");
                         getLogger().warning("!!! ENABLE 'auto-update-schema: true' IN CONFIG TO FIX AUTOMATICALLY !!!");
                         getLogger().warning(BANNER);
@@ -351,7 +375,8 @@ public class MCDataBridge extends JavaPlugin {
         }
     }
 
-    private void migrateStatisticsColumn(Connection connection, Statement statement, String dbType) throws SQLException {
+    private void migrateStatisticsColumn(Connection connection, Statement statement, String dbType)
+            throws SQLException {
         if (dbType.equals(SQLITE)) {
             return;
         }
@@ -359,19 +384,28 @@ public class MCDataBridge extends JavaPlugin {
         String statisticsTable = tablePrefix + "databridge_statistics";
         String escapedStatistics = "`" + statisticsTable + "`";
 
-        try (ResultSet columns = connection.getMetaData().getColumns(null, null, statisticsTable, "vanilla_stats_json")) {
+        try (ResultSet columns = connection.getMetaData().getColumns(null, null, statisticsTable,
+                "vanilla_stats_json")) {
             if (columns.next()) {
                 String typeName = columns.getString("TYPE_NAME");
                 if ("TEXT".equalsIgnoreCase(typeName)) {
                     if (getConfig().getBoolean(AUTO_UPDATE_SCHEMA, false)) {
-                        getLogger().log(java.util.logging.Level.INFO, "Migrating 'vanilla_stats_json' column in {0} from TEXT to LONGTEXT...", statisticsTable);
-                        statement.executeUpdate(ALTER_TABLE_SQL + escapedStatistics + " MODIFY COLUMN vanilla_stats_json LONGTEXT DEFAULT NULL");
+                        getLogger().log(java.util.logging.Level.INFO,
+                                "Migrating 'vanilla_stats_json' column in {0} from TEXT to LONGTEXT...",
+                                statisticsTable);
+                        statement.executeUpdate(ALTER_TABLE_SQL + escapedStatistics
+                                + " MODIFY COLUMN vanilla_stats_json LONGTEXT DEFAULT NULL");
                     } else {
                         getLogger().warning(BANNER);
-                        getLogger().log(java.util.logging.Level.WARNING, "!!! STATISTICS TABLE IS USING {0} FOR 'vanilla_stats_json' COLUMN. !!!", typeName);
-                        getLogger().warning("!!! IT IS HIGHLY RECOMMENDED TO SWITCH TO 'LONGTEXT' TO PREVENT DATA TRUNCATION ERRORS. !!!");
-                        getLogger().warning("!!! ENABLE 'auto-update-schema: true' IN CONFIG TO FIX AUTOMATICALLY, OR RUN: !!!");
-                        getLogger().log(java.util.logging.Level.WARNING, "!!! ALTER TABLE {0} MODIFY COLUMN vanilla_stats_json LONGTEXT DEFAULT NULL; !!!", escapedStatistics);
+                        getLogger().log(java.util.logging.Level.WARNING,
+                                "!!! STATISTICS TABLE IS USING {0} FOR 'vanilla_stats_json' COLUMN. !!!", typeName);
+                        getLogger().warning(
+                                "!!! IT IS HIGHLY RECOMMENDED TO SWITCH TO 'LONGTEXT' TO PREVENT DATA TRUNCATION ERRORS. !!!");
+                        getLogger().warning(
+                                "!!! ENABLE 'auto-update-schema: true' IN CONFIG TO FIX AUTOMATICALLY, OR RUN: !!!");
+                        getLogger().log(java.util.logging.Level.WARNING,
+                                "!!! ALTER TABLE {0} MODIFY COLUMN vanilla_stats_json LONGTEXT DEFAULT NULL; !!!",
+                                escapedStatistics);
                         getLogger().warning(BANNER);
                     }
                 }
@@ -391,12 +425,16 @@ public class MCDataBridge extends JavaPlugin {
             int affectedRows = statement.executeUpdate();
 
             if (affectedRows > 0) {
-                getLogger().log(java.util.logging.Level.INFO, "Released {0} orphaned player data locks for server: {1}", new Object[]{affectedRows, this.serverId});
+                getLogger().log(java.util.logging.Level.INFO, "Released {0} orphaned player data locks for server: {1}",
+                        new Object[] { affectedRows, this.serverId });
             } else {
-                getLogger().log(java.util.logging.Level.INFO, "No orphaned player data locks found for server: {0}", this.serverId);
+                getLogger().log(java.util.logging.Level.INFO, "No orphaned player data locks found for server: {0}",
+                        this.serverId);
             }
         } catch (Exception e) {
-            getLogger().log(java.util.logging.Level.SEVERE, "CRITICAL: Could not release player data locks for {0}! Error: {1}", new Object[]{this.serverId, e.getMessage()});
+            getLogger().log(java.util.logging.Level.SEVERE,
+                    "CRITICAL: Could not release player data locks for {0}! Error: {1}",
+                    new Object[] { this.serverId, e.getMessage() });
         }
     }
 
@@ -450,9 +488,11 @@ public class MCDataBridge extends JavaPlugin {
 
     private void updateConfig() {
         java.io.File configFile = new java.io.File(getDataFolder(), "config.yml");
-        if (!configFile.exists()) return;
+        if (!configFile.exists())
+            return;
 
-        org.bukkit.configuration.file.YamlConfiguration fileConfig = org.bukkit.configuration.file.YamlConfiguration.loadConfiguration(configFile);
+        org.bukkit.configuration.file.YamlConfiguration fileConfig = org.bukkit.configuration.file.YamlConfiguration
+                .loadConfiguration(configFile);
         java.util.List<String> lines;
         try {
             lines = java.nio.file.Files.readAllLines(configFile.toPath(), java.nio.charset.StandardCharsets.UTF_8);
@@ -470,7 +510,8 @@ public class MCDataBridge extends JavaPlugin {
         }
     }
 
-    private boolean checkTopLevelKeys(org.bukkit.configuration.file.YamlConfiguration fileConfig, StringBuilder appends) {
+    private boolean checkTopLevelKeys(org.bukkit.configuration.file.YamlConfiguration fileConfig,
+            StringBuilder appends) {
         boolean updated = false;
         if (!fileConfig.contains("debug")) {
             appends.append("\n# Enable debug mode for verbose logging.\ndebug: false\n");
@@ -497,15 +538,18 @@ public class MCDataBridge extends JavaPlugin {
             updated = true;
         }
         if (!fileConfig.contains("security.seed")) {
-            appends.append("\n# A secret seed used to salt all cryptographic hashes.\nsecurity:\n  seed: \"" + DEFAULT_SEED + "\"\n");
+            appends.append("\n# A secret seed used to salt all cryptographic hashes.\nsecurity:\n  seed: \""
+                    + DEFAULT_SEED + "\"\n");
             updated = true;
         }
         if (!fileConfig.contains("identity.mode")) {
-            appends.append("\n# Identity and Migration Settings\nidentity:\n  mode: PREMIUM\n  auto-migrate-fastlogin: false\n");
+            appends.append(
+                    "\n# Identity and Migration Settings\nidentity:\n  mode: PREMIUM\n  auto-migrate-fastlogin: false\n");
             updated = true;
         }
         if (!fileConfig.contains("companions.scan-radius")) {
-            appends.append("\n# Companion/pet sync settings. Requires sync-data.companions: true.\ncompanions:\n  scan-radius: 32\n  mode: \"follow\"\n");
+            appends.append(
+                    "\n# Companion/pet sync settings. Requires sync-data.companions: true.\ncompanions:\n  scan-radius: 32\n  mode: \"follow\"\n");
             updated = true;
         } else if (!fileConfig.contains("companions.mode")) {
             appends.append("\ncompanions:\n  mode: \"follow\"\n");
@@ -514,8 +558,9 @@ public class MCDataBridge extends JavaPlugin {
         return updated;
     }
 
-    private boolean checkSyncKeys(org.bukkit.configuration.file.YamlConfiguration fileConfig, java.util.List<String> lines, StringBuilder appends) {
-        String[] syncKeys = {"statistics", "pdc", "flight-gamemode", "companions"};
+    private boolean checkSyncKeys(org.bukkit.configuration.file.YamlConfiguration fileConfig,
+            java.util.List<String> lines, StringBuilder appends) {
+        String[] syncKeys = { "statistics", "pdc", "flight-gamemode", "companions" };
         java.util.List<String> missing = new java.util.ArrayList<>();
         for (String key : syncKeys) {
             if (!fileConfig.contains(SYNC_DATA_PREFIX + key)) {
@@ -523,7 +568,8 @@ public class MCDataBridge extends JavaPlugin {
             }
         }
 
-        if (missing.isEmpty()) return false;
+        if (missing.isEmpty())
+            return false;
 
         int syncDataLine = -1;
         for (int i = 0; i < lines.size(); i++) {

--- a/src/main/java/com/digitalserverhost/plugins/commands/BridgeCommand.java
+++ b/src/main/java/com/digitalserverhost/plugins/commands/BridgeCommand.java
@@ -1,148 +1,344 @@
 package com.digitalserverhost.plugins.commands;
 
+import com.digitalserverhost.plugins.MCDataBridge;
 import com.digitalserverhost.plugins.managers.DatabaseManager;
+import com.digitalserverhost.plugins.utils.DataManagementGUI;
+import com.digitalserverhost.plugins.utils.MessageUtils;
+import com.digitalserverhost.plugins.utils.PaperProfileUtils;
+import com.digitalserverhost.plugins.utils.SchedulerUtils;
 import org.bukkit.Bukkit;
 import org.bukkit.command.Command;
-import org.bukkit.command.CommandExecutor;
 import org.bukkit.command.CommandSender;
+import org.bukkit.command.TabExecutor;
+import org.bukkit.entity.Player;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 import java.util.UUID;
 
-public class BridgeCommand implements CommandExecutor {
+public class BridgeCommand implements TabExecutor {
 
     private static final String PLUGIN_NAME = "mc-data-bridge";
+    private static final String CMD_INSPECT = "inspect";
+    private static final String CMD_INVSEE = "invsee";
+    private static final String CMD_ENDERSEE = "endersee";
+    private static final String CMD_MIGRATE = "migrate";
+    private static final String CMD_UNLOCK = "unlock";
+    private static final String FLAG_EDIT = "--edit";
+
+    private static final String PERM_ADMIN = "databridge.admin";
+    private static final String PERM_INSPECT = "databridge.inspect";
+    private static final String PERM_INSPECT_EDIT = "databridge.inspect.edit";
+
+    private static final String VIEW_INVENTORY = "inventory";
+    private static final String VIEW_ENDERCHEST = "enderchest";
+
+    private static final String MSG_PLAYER_ONLY = "§cThis command can only be used by players.";
+
     private final DatabaseManager databaseManager;
+    private final DataManagementGUI guiManager;
+
+    public BridgeCommand(DatabaseManager databaseManager, DataManagementGUI guiManager) {
+        this.databaseManager = databaseManager;
+        this.guiManager = guiManager;
+    }
 
     public BridgeCommand(DatabaseManager databaseManager) {
-        this.databaseManager = databaseManager;
+        this(databaseManager, null);
     }
 
     @Override
     public boolean onCommand(@NotNull CommandSender sender, @NotNull Command command, @NotNull String label,
             @NotNull String[] args) {
-        if (!sender.hasPermission("databridge.admin")) {
-            com.digitalserverhost.plugins.utils.MessageUtils.sendMessage(sender, "&cYou do not have permission to use this command.");
-            return true;
-        }
-
         if (args.length < 1) {
-            com.digitalserverhost.plugins.utils.MessageUtils.sendMessage(sender, "&cUsage: /databridge <unlock|inspect|migrate> <args>");
-            return true;
+            return false;
         }
 
         String subCommand = args[0].toLowerCase();
 
         switch (subCommand) {
-            case "unlock":
+            case CMD_UNLOCK:
+                if (!checkBasePermission(sender)) return true;
                 handleUnlock(sender, args);
-                break;
-            case "inspect":
+                return true;
+            case CMD_INSPECT:
+                if (!checkInspectPermission(sender)) return true;
                 handleInspect(sender, args);
-                break;
-            case "migrate":
+                return true;
+            case CMD_INVSEE:
+                if (!checkInspectPermission(sender)) return true;
+                handleInvsee(sender, args);
+                return true;
+            case CMD_ENDERSEE:
+                if (!checkInspectPermission(sender)) return true;
+                handleEndersee(sender, args);
+                return true;
+            case CMD_MIGRATE:
+                if (!checkBasePermission(sender)) return true;
                 handleMigrate(sender, args);
-                break;
+                return true;
             default:
                 return false;
+        }
+    }
+
+    private boolean checkBasePermission(CommandSender sender) {
+        if (!sender.hasPermission(PERM_ADMIN)) {
+            MessageUtils.sendMessage(sender, "&cYou do not have permission to use this command.");
+            return false;
         }
         return true;
     }
 
+    private boolean checkInspectPermission(CommandSender sender) {
+        if (!sender.hasPermission(PERM_INSPECT) && !sender.hasPermission(PERM_ADMIN)) {
+            MessageUtils.sendMessage(sender, "&cYou do not have permission to inspect player data.");
+            return false;
+        }
+        return true;
+    }
+
+    private boolean checkEditPermission(CommandSender sender) {
+        if (!sender.hasPermission(PERM_INSPECT_EDIT) && !sender.hasPermission(PERM_ADMIN)) {
+            MessageUtils.sendMessage(sender, "&cYou do not have permission to edit player data (databridge.inspect.edit required).");
+            return false;
+        }
+        return true;
+    }
+
+    private boolean hasEditFlag(String[] args) {
+        for (String arg : args) {
+            if (FLAG_EDIT.equalsIgnoreCase(arg) || "edit".equalsIgnoreCase(arg)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    @Override
+    public @Nullable List<String> onTabComplete(@NotNull CommandSender sender, @NotNull Command command,
+            @NotNull String alias, @NotNull String[] args) {
+        if (!sender.hasPermission(PERM_INSPECT) && !sender.hasPermission(PERM_ADMIN)) {
+            return Collections.emptyList();
+        }
+
+        if (args.length == 1) {
+            return getArg0Completions(args[0]);
+        } else if (args.length == 2) {
+            return getOnlinePlayerCompletions(args[1]);
+        } else if (args.length == 3) {
+            return getArg2Completions(args[0], args[2]);
+        } else if (args.length == 4) {
+            return getArg3Completions(args[0], args[3]);
+        }
+        return Collections.emptyList();
+    }
+
+    private List<String> getArg0Completions(String input) {
+        List<String> completions = new ArrayList<>();
+        String partial = input.toLowerCase();
+        for (String sub : List.of(CMD_UNLOCK, CMD_INSPECT, CMD_INVSEE, CMD_ENDERSEE, CMD_MIGRATE)) {
+            if (sub.startsWith(partial)) {
+                completions.add(sub);
+            }
+        }
+        return completions;
+    }
+
+    @SuppressWarnings("null")
+    private List<String> getOnlinePlayerCompletions(String input) {
+        List<String> completions = new ArrayList<>();
+        String partial = input.toLowerCase();
+        for (Player player : Bukkit.getOnlinePlayers()) {
+            if (player.getName().toLowerCase().startsWith(partial)) {
+                completions.add(player.getName());
+            }
+        }
+        return completions;
+    }
+
+    private List<String> getArg2Completions(String subCommand, String input) {
+        String partial = input.toLowerCase();
+        if (CMD_INSPECT.equalsIgnoreCase(subCommand)) {
+            List<String> completions = new ArrayList<>();
+            for (String option : List.of(VIEW_INVENTORY, VIEW_ENDERCHEST, FLAG_EDIT)) {
+                if (option.startsWith(partial)) {
+                    completions.add(option);
+                }
+            }
+            return completions;
+        } else if (CMD_INVSEE.equalsIgnoreCase(subCommand) || CMD_ENDERSEE.equalsIgnoreCase(subCommand)) {
+            List<String> completions = new ArrayList<>();
+            if (FLAG_EDIT.startsWith(partial)) {
+                completions.add(FLAG_EDIT);
+            }
+            return completions;
+        } else if (CMD_MIGRATE.equalsIgnoreCase(subCommand)) {
+            return getOnlinePlayerCompletions(input);
+        }
+        return Collections.emptyList();
+    }
+
+    private List<String> getArg3Completions(String subCommand, String input) {
+        String partial = input.toLowerCase();
+        if (CMD_INSPECT.equalsIgnoreCase(subCommand)) {
+            List<String> completions = new ArrayList<>();
+            if (FLAG_EDIT.startsWith(partial)) {
+                completions.add(FLAG_EDIT);
+            }
+            return completions;
+        }
+        return Collections.emptyList();
+    }
+
     private void handleUnlock(CommandSender sender, String[] args) {
         if (args.length < 2) {
-            com.digitalserverhost.plugins.utils.MessageUtils.sendMessage(sender, "&cUsage: /databridge unlock <player>");
+            MessageUtils.sendMessage(sender, "&cUsage: /databridge unlock <player>");
             return;
         }
         String targetName = args[1];
-        Bukkit.getScheduler().runTaskAsynchronously(Bukkit.getPluginManager().getPlugin(PLUGIN_NAME), () -> {
+        Bukkit.getScheduler().runTaskAsynchronously(getPlugin(), () -> {
             UUID uuid = resolveUuid(targetName);
             if (uuid == null) {
-                com.digitalserverhost.plugins.utils.MessageUtils.sendMessage(sender, "&cCould not resolve player " + targetName);
+                MessageUtils.sendMessage(sender, "&cCould not resolve player " + targetName);
                 return;
             }
 
             boolean success = databaseManager.releaseLock(uuid);
             if (success) {
-                com.digitalserverhost.plugins.utils.MessageUtils.sendMessage(sender, 
+                MessageUtils.sendMessage(sender, 
                         "&aSuccessfully released lock for player " + targetName + " (" + uuid + ")");
             } else {
-                com.digitalserverhost.plugins.utils.MessageUtils.sendMessage(sender, 
+                MessageUtils.sendMessage(sender, 
                         "&cFailed to release lock for " + targetName + ". Check console for errors.");
             }
         });
     }
 
     private void handleInspect(CommandSender sender, String[] args) {
-        if (!(sender instanceof org.bukkit.entity.Player)) {
-            sender.sendMessage("§cThis command can only be used by players.");
+        if (!(sender instanceof Player admin)) {
+            sender.sendMessage(MSG_PLAYER_ONLY);
             return;
         }
         if (args.length < 2) {
-            com.digitalserverhost.plugins.utils.MessageUtils.sendMessage(sender, "&cUsage: /databridge inspect <player>");
+            MessageUtils.sendMessage(sender, "&cUsage: /databridge inspect <player> [inventory|enderchest] [--edit]");
             return;
         }
-        org.bukkit.entity.Player admin = (org.bukkit.entity.Player) sender;
         String targetName = args[1];
-        
-        Bukkit.getScheduler().runTaskAsynchronously(Bukkit.getPluginManager().getPlugin(PLUGIN_NAME), () -> {
+        boolean wantEdit = hasEditFlag(args);
+        if (wantEdit && !checkEditPermission(admin)) return;
+
+        String viewType = "overview";
+        if (args.length >= 3 && !args[2].startsWith("-") && !"edit".equalsIgnoreCase(args[2])) {
+            viewType = args[2].toLowerCase();
+        }
+
+        openGuiForPlayer(admin, targetName, viewType, wantEdit);
+    }
+
+    private void handleInvsee(CommandSender sender, String[] args) {
+        if (!(sender instanceof Player admin)) {
+            sender.sendMessage(MSG_PLAYER_ONLY);
+            return;
+        }
+        if (args.length < 2) {
+            MessageUtils.sendMessage(sender, "&cUsage: /databridge invsee <player> [--edit]");
+            return;
+        }
+        boolean wantEdit = hasEditFlag(args);
+        if (wantEdit && !checkEditPermission(admin)) return;
+
+        openGuiForPlayer(admin, args[1], VIEW_INVENTORY, wantEdit);
+    }
+
+    private void handleEndersee(CommandSender sender, String[] args) {
+        if (!(sender instanceof Player admin)) {
+            sender.sendMessage(MSG_PLAYER_ONLY);
+            return;
+        }
+        if (args.length < 2) {
+            MessageUtils.sendMessage(sender, "&cUsage: /databridge endersee <player> [--edit]");
+            return;
+        }
+        boolean wantEdit = hasEditFlag(args);
+        if (wantEdit && !checkEditPermission(admin)) return;
+
+        openGuiForPlayer(admin, args[1], VIEW_ENDERCHEST, wantEdit);
+    }
+
+    private void openGuiForPlayer(Player admin, String targetName, String viewType, boolean isEditable) {
+        Bukkit.getScheduler().runTaskAsynchronously(getPlugin(), () -> {
             UUID uuid = resolveUuid(targetName);
             if (uuid == null) {
-                com.digitalserverhost.plugins.utils.MessageUtils.sendMessage(admin, "&cCould not resolve player " + targetName);
+                MessageUtils.sendMessage(admin, "&cCould not resolve player " + targetName);
                 return;
             }
 
-            com.digitalserverhost.plugins.MCDataBridge plugin = (com.digitalserverhost.plugins.MCDataBridge) Bukkit.getPluginManager().getPlugin(PLUGIN_NAME);
-            new com.digitalserverhost.plugins.utils.DataManagementGUI(plugin, databaseManager).openPlayerInspector(admin, uuid, targetName);
+            MCDataBridge plugin = getPlugin();
+            DataManagementGUI gui = (guiManager != null) ? guiManager : new DataManagementGUI(plugin, databaseManager);
+
+            if (VIEW_INVENTORY.equals(viewType)) {
+                gui.openInventoryView(admin, uuid, targetName, isEditable);
+            } else if (VIEW_ENDERCHEST.equals(viewType)) {
+                gui.openEnderChestView(admin, uuid, targetName, isEditable);
+            } else {
+                gui.openPlayerInspector(admin, uuid, targetName, isEditable);
+            }
         });
     }
 
     private void handleMigrate(CommandSender sender, String[] args) {
         if (args.length < 3) {
-            com.digitalserverhost.plugins.utils.MessageUtils.sendMessage(sender, "&cUsage: /databridge migrate <source> <target>");
+            MessageUtils.sendMessage(sender, "&cUsage: /databridge migrate <source> <target>");
             return;
         }
         String sourceInput = args[1];
         String targetInput = args[2];
 
-        Bukkit.getScheduler().runTaskAsynchronously(Bukkit.getPluginManager().getPlugin(PLUGIN_NAME), () -> {
+        Bukkit.getScheduler().runTaskAsynchronously(getPlugin(), () -> {
             UUID sourceUuid = resolveUuid(sourceInput);
             UUID targetUuid = resolveUuid(targetInput);
 
             if (sourceUuid == null) {
-                com.digitalserverhost.plugins.utils.MessageUtils.sendMessage(sender, "&cCould not resolve source player: " + sourceInput);
+                MessageUtils.sendMessage(sender, "&cCould not resolve source player: " + sourceInput);
                 return;
             }
             if (targetUuid == null) {
-                com.digitalserverhost.plugins.utils.MessageUtils.sendMessage(sender, "&cCould not resolve target player: " + targetInput);
+                MessageUtils.sendMessage(sender, "&cCould not resolve target player: " + targetInput);
                 return;
             }
 
             try {
                 boolean success = databaseManager.migrateData(sourceUuid, targetUuid);
                 if (success) {
-                    com.digitalserverhost.plugins.utils.MessageUtils.sendMessage(sender, "&aSuccessfully migrated data from " + sourceInput + " to " + targetInput);
+                    MessageUtils.sendMessage(sender, "&aSuccessfully migrated data from " + sourceInput + " to " + targetInput);
                 } else {
-                    com.digitalserverhost.plugins.utils.MessageUtils.sendMessage(sender, "&cMigration failed. Ensure the source player has data.");
+                    MessageUtils.sendMessage(sender, "&cMigration failed. Ensure the source player has data.");
                 }
             } catch (Exception e) {
-                com.digitalserverhost.plugins.utils.MessageUtils.sendMessage(sender, "&cError during migration: " + e.getMessage());
+                MessageUtils.sendMessage(sender, "&cError during migration: " + e.getMessage());
             }
         });
+    }
+
+    private MCDataBridge getPlugin() {
+        return (MCDataBridge) Bukkit.getPluginManager().getPlugin(PLUGIN_NAME);
     }
 
     private UUID resolveUuid(String input) {
         try {
             return UUID.fromString(input);
         } catch (IllegalArgumentException _) {
-            // Try DB first
             UUID dbUuid = databaseManager.getUuidByName(input);
             if (dbUuid != null) return dbUuid;
 
-            if (com.digitalserverhost.plugins.utils.SchedulerUtils.isPaper()) {
-                return com.digitalserverhost.plugins.utils.PaperProfileUtils.resolveUuid(input);
+            if (SchedulerUtils.isPaper()) {
+                return PaperProfileUtils.resolveUuid(input);
             } else {
-                return org.bukkit.Bukkit.getOfflinePlayer(input).getUniqueId();
+                return Bukkit.getOfflinePlayer(input).getUniqueId();
             }
         }
     }

--- a/src/main/java/com/digitalserverhost/plugins/listeners/PlayerListener.java
+++ b/src/main/java/com/digitalserverhost/plugins/listeners/PlayerListener.java
@@ -67,6 +67,7 @@ public class PlayerListener implements Listener, PluginMessageListener {
                 }
 
                 switchingPlayers.put(uuid, true);
+                safelyCloseInventory(playerToSave);
                 savePlayerDataAndReleaseLock(playerToSave);
             }
         } else if (subchannel.equals("ForceUnlock")) {
@@ -304,6 +305,7 @@ public class PlayerListener implements Listener, PluginMessageListener {
 
         final PlayerData finalData;
         try {
+            safelyCloseInventory(player);
             finalData = new PlayerData(player, plugin);
         } catch (Exception e) {
             plugin.getLogger().log(Level.SEVERE, "Failed to create final data snapshot for {0}. Data will not be saved. Error: {1}", new Object[]{name, e.getMessage()});
@@ -392,8 +394,7 @@ public class PlayerListener implements Listener, PluginMessageListener {
  
                 plugin.getLogger().log(Level.INFO, "Successfully applied data to player {0}", player.getName());
             } catch (Exception e) {
-                plugin.getLogger().log(Level.SEVERE, "A critical error occurred while applying data to player {0}. {1}", new Object[]{player.getName(), e.getMessage()});
-                e.printStackTrace();
+                plugin.getLogger().log(Level.SEVERE, e, () -> "A critical error occurred while applying data to player " + player.getName());
             }
         });
     }
@@ -697,5 +698,64 @@ public class PlayerListener implements Listener, PluginMessageListener {
             plugin.getLogger().log(Level.SEVERE, "Failed to load player data for {0}: {1}", new Object[]{uuid, e.getMessage()});
         }
         return null;
+    }
+
+    public boolean isPlayerLocked(UUID uuid) {
+        return uuid != null && (switchingPlayers.containsKey(uuid) || savingPlayers.containsKey(uuid));
+    }
+
+    private void safelyCloseInventory(Player player) {
+        if (player == null) return;
+        try {
+            com.digitalserverhost.plugins.utils.SchedulerUtils.runOnEntity(plugin, player, player::closeInventory);
+        } catch (Exception e) {
+            if (plugin.isDebugMode()) {
+                plugin.getLogger().log(Level.WARNING, "Failed to close inventory for {0}: {1}", new Object[]{player.getName(), e.getMessage()});
+            }
+        }
+    }
+
+    @EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)
+    public void onInventoryClick(org.bukkit.event.inventory.InventoryClickEvent event) {
+        if (event.getWhoClicked() instanceof Player player && isPlayerLocked(player.getUniqueId())) {
+            event.setCancelled(true);
+        }
+    }
+
+    @EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)
+    public void onInventoryDrag(org.bukkit.event.inventory.InventoryDragEvent event) {
+        if (event.getWhoClicked() instanceof Player player && isPlayerLocked(player.getUniqueId())) {
+            event.setCancelled(true);
+        }
+    }
+
+    @EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)
+    public void onPlayerDropItem(org.bukkit.event.player.PlayerDropItemEvent event) {
+        if (isPlayerLocked(event.getPlayer().getUniqueId())) {
+            event.setCancelled(true);
+        }
+    }
+
+    @EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)
+    public void onEntityPickupItem(org.bukkit.event.entity.EntityPickupItemEvent event) {
+        if (event.getEntity() instanceof Player player && isPlayerLocked(player.getUniqueId())) {
+            event.setCancelled(true);
+        }
+    }
+
+    @EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)
+    public void onPlayerInteract(org.bukkit.event.player.PlayerInteractEvent event) {
+        if (isPlayerLocked(event.getPlayer().getUniqueId())) {
+            event.setCancelled(true);
+            event.setUseInteractedBlock(org.bukkit.event.Event.Result.DENY);
+            event.setUseItemInHand(org.bukkit.event.Event.Result.DENY);
+        }
+    }
+
+    @EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)
+    public void onPlayerInteractEntity(org.bukkit.event.player.PlayerInteractEntityEvent event) {
+        if (isPlayerLocked(event.getPlayer().getUniqueId())) {
+            event.setCancelled(true);
+        }
     }
 }

--- a/src/main/java/com/digitalserverhost/plugins/managers/DatabaseManager.java
+++ b/src/main/java/com/digitalserverhost/plugins/managers/DatabaseManager.java
@@ -366,10 +366,10 @@ public class DatabaseManager {
 
     public List<String> deserializeListFromBlob(byte[] blob) {
         if (blob == null) return new ArrayList<>();
-        if ("binary".equals(serializationFormat) || (blob.length > 2 && blob[0] != (byte) '[')) {
-            return deserializeListFromBinary(blob);
-        } else {
+        if (blob.length > 0 && blob[0] == (byte) '[') {
             return deserializeListFromJson(blob);
+        } else {
+            return deserializeListFromBinary(blob);
         }
     }
 
@@ -479,6 +479,13 @@ public class DatabaseManager {
             } finally {
                 connection.setAutoCommit(true);
             }
+        }
+    }
+
+    public boolean saveInventoryComponent(com.digitalserverhost.plugins.MCDataBridge plugin, PlayerData data, UUID uuid) throws SQLException {
+        try (Connection connection = getConnection()) {
+            saveInventoryComponent(connection, plugin, data, uuid);
+            return true;
         }
     }
 

--- a/src/main/java/com/digitalserverhost/plugins/proxy/velocity/VelocityMCDataBridge.java
+++ b/src/main/java/com/digitalserverhost/plugins/proxy/velocity/VelocityMCDataBridge.java
@@ -8,7 +8,7 @@ import com.velocitypowered.api.event.Subscribe;
 import com.velocitypowered.api.event.proxy.ProxyInitializeEvent;
 import com.velocitypowered.api.proxy.messages.MinecraftChannelIdentifier;
 
-@Plugin(id = "mc-data-bridge", name = "mc-data-bridge", version = "2.1.7", authors = {
+@Plugin(id = "mc-data-bridge", name = "mc-data-bridge", version = "2.1.8", authors = {
         "DigitalServerHost" })
 public class VelocityMCDataBridge {
 

--- a/src/main/java/com/digitalserverhost/plugins/utils/DataManagementGUI.java
+++ b/src/main/java/com/digitalserverhost/plugins/utils/DataManagementGUI.java
@@ -5,20 +5,60 @@ import com.digitalserverhost.plugins.managers.DatabaseManager;
 import org.bukkit.Bukkit;
 import org.bukkit.Material;
 import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
+import org.bukkit.event.Listener;
+import org.bukkit.event.inventory.InventoryClickEvent;
+import org.bukkit.event.inventory.InventoryCloseEvent;
 import org.bukkit.inventory.Inventory;
+import org.bukkit.inventory.InventoryHolder;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;
-import org.jetbrains.annotations.Nullable;
 import org.jetbrains.annotations.NotNull;
 
-import java.sql.Connection;
-import java.sql.PreparedStatement;
-import java.sql.ResultSet;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
+import java.util.logging.Level;
 
-public class DataManagementGUI {
+public class DataManagementGUI implements Listener {
+
+    private static final String TITLE_INSPECT = "§8Inspecting: §1";
+    private static final String TITLE_INVENTORY_VIEW = "§8Inventory: §1";
+    private static final String TITLE_INVENTORY_EDIT = "§cEdit Inventory: §1";
+    private static final String TITLE_ENDERCHEST_VIEW = "§8EnderChest: §1";
+    private static final String TITLE_ENDERCHEST_EDIT = "§cEdit EnderChest: §1";
+
+    public enum ViewType { OVERVIEW, INVENTORY, ENDERCHEST }
+
+    public static class DataBridgeGUIHolder implements InventoryHolder {
+        private final UUID targetUuid;
+        private final String targetName;
+        private final ViewType viewType;
+        private final boolean isEditable;
+        private Inventory inventory;
+
+        public DataBridgeGUIHolder(UUID targetUuid, String targetName, ViewType viewType, boolean isEditable) {
+            this.targetUuid = targetUuid;
+            this.targetName = targetName;
+            this.viewType = viewType;
+            this.isEditable = isEditable;
+        }
+
+        @Override
+        public Inventory getInventory() {
+            return inventory;
+        }
+
+        public void setInventory(Inventory inventory) {
+            this.inventory = inventory;
+        }
+
+        public UUID getTargetUuid() { return targetUuid; }
+        public String getTargetName() { return targetName; }
+        public ViewType getViewType() { return viewType; }
+        public boolean isEditable() { return isEditable; }
+    }
 
     private final MCDataBridge plugin;
     private final DatabaseManager databaseManager;
@@ -28,31 +68,14 @@ public class DataManagementGUI {
         this.databaseManager = databaseManager;
     }
 
-    public void openPlayerInspector(Player admin, UUID targetUuid, String targetName) {
+    public void openPlayerInspector(Player admin, UUID targetUuid, String targetName, boolean isEditable) {
         Bukkit.getScheduler().runTaskAsynchronously(plugin, () -> {
-            try (Connection connection = databaseManager.getConnection()) {
-                String query = "SELECT data FROM " + databaseManager.getTableName() + " WHERE uuid = ?";
-                PreparedStatement statement = connection.prepareStatement(query);
-                statement.setString(1, targetUuid.toString());
-                ResultSet resultSet = statement.executeQuery();
-
-                if (resultSet.next()) {
-                    byte[] dataBytes = resultSet.getBytes("data");
-                    String json = (dataBytes != null) ? new String(dataBytes, java.nio.charset.StandardCharsets.UTF_8)
-                            : null;
-
-                    if (json != null && !json.trim().isEmpty()) {
-                        PlayerData data = fromJsonSafe(json, PlayerData.class);
-                        java.util.Optional.ofNullable(data)
-                                .ifPresentOrElse(
-                                        d -> SchedulerUtils.runOnEntity(plugin, admin,
-                                                () -> buildAndOpenGUI(admin, targetName, d)),
-                                        () -> MessageUtils.sendMessage(admin, "§cFailed to parse player data for: " + targetName));
-                    } else {
-                        MessageUtils.sendMessage(admin, "§cNo data found for player: " + targetName);
-                    }
+            try {
+                PlayerData data = databaseManager.loadPlayerDataComponents(plugin, targetUuid, targetName);
+                if (data != null) {
+                    SchedulerUtils.runOnEntity(plugin, admin, () -> buildAndOpenGUI(admin, targetUuid, targetName, data, isEditable));
                 } else {
-                    MessageUtils.sendMessage(admin, "§cPlayer " + targetName + " not found in database.");
+                    MessageUtils.sendMessage(admin, "§cNo player data found for: " + targetName);
                 }
             } catch (Exception e) {
                 MessageUtils.sendMessage(admin, "§cError loading player data: " + e.getMessage());
@@ -60,42 +83,265 @@ public class DataManagementGUI {
         });
     }
 
-    @SuppressWarnings("deprecation")
-    private void buildAndOpenGUI(@NotNull Player admin, @NotNull String targetName, @NotNull PlayerData data) {
-        String title = "§8Inspecting: §1" + targetName;
-        Inventory inv = Bukkit.createInventory(null, 27, title);
+    public void openPlayerInspector(Player admin, UUID targetUuid, String targetName) {
+        openPlayerInspector(admin, targetUuid, targetName, false);
+    }
 
-        // Stats Item
+    public void openInventoryView(Player admin, UUID targetUuid, String targetName, boolean isEditable) {
+        Bukkit.getScheduler().runTaskAsynchronously(plugin, () -> {
+            try {
+                PlayerData data = databaseManager.loadPlayerDataComponents(plugin, targetUuid, targetName);
+                if (data != null) {
+                    SchedulerUtils.runOnEntity(plugin, admin, () -> buildAndOpenInventoryGUI(admin, targetUuid, targetName, data, isEditable));
+                } else {
+                    MessageUtils.sendMessage(admin, "§cNo inventory data found for: " + targetName);
+                }
+            } catch (Exception e) {
+                MessageUtils.sendMessage(admin, "§cError loading inventory data: " + e.getMessage());
+            }
+        });
+    }
+
+    public void openInventoryView(Player admin, UUID targetUuid, String targetName) {
+        openInventoryView(admin, targetUuid, targetName, false);
+    }
+
+    public void openEnderChestView(Player admin, UUID targetUuid, String targetName, boolean isEditable) {
+        Bukkit.getScheduler().runTaskAsynchronously(plugin, () -> {
+            try {
+                PlayerData data = databaseManager.loadPlayerDataComponents(plugin, targetUuid, targetName);
+                if (data != null) {
+                    SchedulerUtils.runOnEntity(plugin, admin, () -> buildAndOpenEnderChestGUI(admin, targetUuid, targetName, data, isEditable));
+                } else {
+                    MessageUtils.sendMessage(admin, "§cNo ender chest data found for: " + targetName);
+                }
+            } catch (Exception e) {
+                MessageUtils.sendMessage(admin, "§cError loading ender chest data: " + e.getMessage());
+            }
+        });
+    }
+
+    public void openEnderChestView(Player admin, UUID targetUuid, String targetName) {
+        openEnderChestView(admin, targetUuid, targetName, false);
+    }
+
+    @SuppressWarnings("deprecation")
+    private void buildAndOpenGUI(@NotNull Player admin, @NotNull UUID targetUuid, @NotNull String targetName, @NotNull PlayerData data, boolean isEditable) {
+        String title = TITLE_INSPECT + targetName;
+        DataBridgeGUIHolder holder = new DataBridgeGUIHolder(targetUuid, targetName, ViewType.OVERVIEW, isEditable);
+        Inventory inv = Bukkit.createInventory(holder, 27, title);
+        holder.setInventory(inv);
+
+        boolean canEdit = admin.hasPermission("databridge.inspect.edit") || admin.hasPermission("databridge.admin");
+
         inv.setItem(10, createInfoItem(Material.PLAYER_HEAD, "§b§lPlayer Stats",
                 "§7Health: §f" + String.format("%.1f", data.getHealth()),
                 "§7Level: §f" + data.getLevel(),
                 "§7Exp: §f" + String.format("%.2f", data.getExp()),
                 "§7Food: §f" + data.getFoodLevel()));
 
-        // Inventory Overview
         int invSize = data.getInventoryContents() != null ? data.getInventoryContents().length : 0;
-        inv.setItem(12, createInfoItem(Material.CHEST, "§6§lInventory",
-                "§7Items Tracked: §f" + invSize));
+        List<String> invLore = new ArrayList<>();
+        invLore.add("§7Items Tracked: §f" + invSize);
+        invLore.add("§eLeft-Click: §fView Inventory (Read-Only)");
+        if (canEdit) {
+            invLore.add("§cRight-Click: §fEdit Inventory (Interactive)");
+        }
+        inv.setItem(12, createInfoItem(Material.CHEST, "§6§lInventory", invLore.toArray(new String[0])));
 
-        // Ender Chest Overview
         int ecSize = data.getEnderChestContents() != null ? data.getEnderChestContents().length : 0;
-        inv.setItem(13, createInfoItem(Material.ENDER_CHEST, "§d§lEnder Chest",
-                "§7Items Tracked: §f" + ecSize));
+        List<String> ecLore = new ArrayList<>();
+        ecLore.add("§7Items Tracked: §f" + ecSize);
+        ecLore.add("§eLeft-Click: §fView Ender Chest (Read-Only)");
+        if (canEdit) {
+            ecLore.add("§cRight-Click: §fEdit Ender Chest (Interactive)");
+        }
+        inv.setItem(13, createInfoItem(Material.ENDER_CHEST, "§d§lEnder Chest", ecLore.toArray(new String[0])));
 
-        // Location Info
         inv.setItem(14, createInfoItem(Material.COMPASS, "§e§lLast Known Location",
                 "§7World: §f" + data.getWorld(),
                 "§7X: §f" + (int) data.getX(),
                 "§7Y: §f" + (int) data.getY(),
                 "§7Z: §f" + (int) data.getZ()));
 
-        // PDC/Metadata Info
         inv.setItem(16, createInfoItem(Material.BOOK, "§5§lMetadata (PDC)",
                 "§7Custom Data: §f" + (data.getPdcNBT() != null ? "Present" : "None")));
 
         admin.openInventory(inv);
     }
- 
+
+    @SuppressWarnings("deprecation")
+    private void buildAndOpenInventoryGUI(@NotNull Player admin, @NotNull UUID targetUuid, @NotNull String targetName, @NotNull PlayerData data, boolean isEditable) {
+        String title = (isEditable ? TITLE_INVENTORY_EDIT : TITLE_INVENTORY_VIEW) + targetName;
+        DataBridgeGUIHolder holder = new DataBridgeGUIHolder(targetUuid, targetName, ViewType.INVENTORY, isEditable);
+        Inventory inv = Bukkit.createInventory(holder, 54, title);
+        holder.setInventory(inv);
+
+        ItemStack[] items = data.getInventoryContents();
+        if (items != null) {
+            for (int i = 0; i < Math.min(items.length, 36); i++) {
+                if (items[i] != null && items[i].getType() != Material.AIR) {
+                    inv.setItem(i, items[i]);
+                }
+            }
+        }
+
+        ItemStack[] armor = data.getArmorContents();
+        if (armor != null) {
+            for (int i = 0; i < Math.min(armor.length, 4); i++) {
+                if (armor[i] != null && armor[i].getType() != Material.AIR) {
+                    inv.setItem(36 + i, armor[i]);
+                }
+            }
+        }
+
+        inv.setItem(49, createInfoItem(Material.ARROW, "§c§lBack to Overview", "§7Click to return to overview"));
+        admin.openInventory(inv);
+    }
+
+    @SuppressWarnings("deprecation")
+    private void buildAndOpenEnderChestGUI(@NotNull Player admin, @NotNull UUID targetUuid, @NotNull String targetName, @NotNull PlayerData data, boolean isEditable) {
+        String title = (isEditable ? TITLE_ENDERCHEST_EDIT : TITLE_ENDERCHEST_VIEW) + targetName;
+        DataBridgeGUIHolder holder = new DataBridgeGUIHolder(targetUuid, targetName, ViewType.ENDERCHEST, isEditable);
+        Inventory inv = Bukkit.createInventory(holder, 36, title);
+        holder.setInventory(inv);
+
+        ItemStack[] items = data.getEnderChestContents();
+        if (items != null) {
+            for (int i = 0; i < Math.min(items.length, 27); i++) {
+                if (items[i] != null && items[i].getType() != Material.AIR) {
+                    inv.setItem(i, items[i]);
+                }
+            }
+        }
+
+        inv.setItem(31, createInfoItem(Material.ARROW, "§c§lBack to Overview", "§7Click to return to overview"));
+        admin.openInventory(inv);
+    }
+
+    @EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)
+    public void onInventoryClick(InventoryClickEvent event) {
+        if (!(event.getWhoClicked() instanceof Player admin)) return;
+        if (!(event.getInventory().getHolder() instanceof DataBridgeGUIHolder holder)) return;
+
+        int rawSlot = event.getRawSlot();
+
+        if (holder.getViewType() == ViewType.OVERVIEW) {
+            handleOverviewClick(event, admin, holder, rawSlot);
+        } else if (holder.getViewType() == ViewType.INVENTORY) {
+            handleViewClick(event, admin, holder, rawSlot, 49);
+        } else if (holder.getViewType() == ViewType.ENDERCHEST) {
+            handleViewClick(event, admin, holder, rawSlot, 31);
+        }
+    }
+
+    private void handleOverviewClick(InventoryClickEvent event, Player admin, DataBridgeGUIHolder holder, int rawSlot) {
+        event.setCancelled(true);
+        boolean isRightClick = event.isRightClick();
+        boolean canEdit = admin.hasPermission("databridge.inspect.edit") || admin.hasPermission("databridge.admin");
+
+        if (rawSlot == 12) {
+            openTargetView(admin, holder, true, isRightClick, canEdit);
+        } else if (rawSlot == 13) {
+            openTargetView(admin, holder, false, isRightClick, canEdit);
+        }
+    }
+
+    private void openTargetView(Player admin, DataBridgeGUIHolder holder, boolean isInventory, boolean isRightClick, boolean canEdit) {
+        if (isRightClick) {
+            if (canEdit) {
+                if (isInventory) {
+                    openInventoryView(admin, holder.getTargetUuid(), holder.getTargetName(), true);
+                } else {
+                    openEnderChestView(admin, holder.getTargetUuid(), holder.getTargetName(), true);
+                }
+            } else {
+                String typeName = isInventory ? "player inventory" : "ender chest";
+                MessageUtils.sendMessage(admin, "&cYou do not have permission to edit " + typeName + " (databridge.inspect.edit required).");
+            }
+        } else {
+            if (isInventory) {
+                openInventoryView(admin, holder.getTargetUuid(), holder.getTargetName(), false);
+            } else {
+                openEnderChestView(admin, holder.getTargetUuid(), holder.getTargetName(), false);
+            }
+        }
+    }
+
+    private void handleViewClick(InventoryClickEvent event, Player admin, DataBridgeGUIHolder holder, int rawSlot, int backSlot) {
+        if (rawSlot == backSlot) {
+            event.setCancelled(true);
+            openPlayerInspector(admin, holder.getTargetUuid(), holder.getTargetName(), holder.isEditable());
+        } else if (!holder.isEditable()) {
+            event.setCancelled(true);
+        }
+    }
+
+    @EventHandler(priority = EventPriority.MONITOR)
+    public void onInventoryClose(InventoryCloseEvent event) {
+        if (!(event.getPlayer() instanceof Player admin)) return;
+        if (!(event.getInventory().getHolder() instanceof DataBridgeGUIHolder holder)) return;
+        if (!holder.isEditable()) return;
+
+        Inventory inv = event.getInventory();
+        UUID targetUuid = holder.getTargetUuid();
+        String targetName = holder.getTargetName();
+        ViewType viewType = holder.getViewType();
+
+        Bukkit.getScheduler().runTaskAsynchronously(plugin, () -> saveEditedInventory(admin, targetUuid, targetName, viewType, inv));
+    }
+
+    private void saveEditedInventory(Player admin, UUID targetUuid, String targetName, ViewType viewType, Inventory inv) {
+        try {
+            PlayerData data = databaseManager.loadPlayerDataComponents(plugin, targetUuid, targetName);
+            if (data == null) data = new PlayerData();
+
+            if (viewType == ViewType.INVENTORY) {
+                ItemStack[] mainItems = new ItemStack[36];
+                for (int i = 0; i < 36; i++) mainItems[i] = inv.getItem(i);
+
+                ItemStack[] armorItems = new ItemStack[4];
+                for (int i = 0; i < 4; i++) armorItems[i] = inv.getItem(36 + i);
+
+                data.setInventoryContentsNBT(serializeItems(mainItems));
+                data.setArmorContentsNBT(serializeItems(armorItems));
+            } else if (viewType == ViewType.ENDERCHEST) {
+                ItemStack[] ecItems = new ItemStack[27];
+                for (int i = 0; i < 27; i++) ecItems[i] = inv.getItem(i);
+
+                data.setEnderChestContentsNBT(serializeItems(ecItems));
+            }
+
+            boolean success = databaseManager.saveInventoryComponent(plugin, data, targetUuid);
+            if (success) {
+                MessageUtils.sendMessage(admin, "&a[DataBridge] Saved modified " + viewType.name().toLowerCase() + " for " + targetName + " to database.");
+            }
+        } catch (Exception e) {
+            plugin.getLogger().log(Level.SEVERE, "Failed to save edited inventory for {0}: {1}", new Object[]{targetName, e.getMessage()});
+            MessageUtils.sendMessage(admin, "&cError saving modified inventory: " + e.getMessage());
+        }
+    }
+
+    private List<String> serializeItems(ItemStack[] items) {
+        List<String> list = new ArrayList<>();
+        com.google.gson.Gson gson = MCDataBridge.getGson();
+        if (items != null) {
+            for (ItemStack item : items) {
+                if (item == null || item.getType() == Material.AIR) {
+                    list.add(null);
+                } else {
+                    try {
+                        PlayerData.SerializableItemStack serializable = new PlayerData.SerializableItemStack(item);
+                        list.add(gson.toJson(serializable));
+                    } catch (Exception _) {
+                        list.add(null);
+                    }
+                }
+            }
+        }
+        return list;
+    }
+
     @SuppressWarnings("deprecation")
     private @NotNull ItemStack createInfoItem(@NotNull Material material, @NotNull String name, @NotNull String... lore) {
         ItemStack item = new ItemStack(material);
@@ -107,9 +353,5 @@ public class DataManagementGUI {
             item.setItemMeta(meta);
         }
         return item;
-    }
-
-    private @Nullable <T> T fromJsonSafe(String json, Class<T> clazz) {
-        return MCDataBridge.getGson().fromJson(json, clazz);
     }
 }

--- a/src/main/java/com/digitalserverhost/plugins/utils/MessageUtils.java
+++ b/src/main/java/com/digitalserverhost/plugins/utils/MessageUtils.java
@@ -5,6 +5,8 @@ import net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer;
 import org.bukkit.command.CommandSender;
 import org.jetbrains.annotations.NotNull;
 
+import java.util.Objects;
+
 /**
  * Utility for sending messages in a platform-agnostic way.
  */
@@ -19,7 +21,8 @@ public class MessageUtils {
         sender.sendMessage(message.replace("&", "§"));
     }
 
+    @SuppressWarnings("null")
     public static @NotNull String serialize(@NotNull Component component) {
-        return LegacyComponentSerializer.legacySection().serialize(component);
+        return Objects.requireNonNull(LegacyComponentSerializer.legacySection().serialize(Objects.requireNonNull(component)));
     }
 }

--- a/src/main/java/com/digitalserverhost/plugins/utils/PaperBridge.java
+++ b/src/main/java/com/digitalserverhost/plugins/utils/PaperBridge.java
@@ -1,15 +1,20 @@
 package com.digitalserverhost.plugins.utils;
 
+import java.util.Objects;
+import org.jetbrains.annotations.NotNull;
+
 public class PaperBridge implements PlatformBridge {
     @Override
-    public void disallowPlayer(org.bukkit.event.player.AsyncPlayerPreLoginEvent event, org.bukkit.event.player.AsyncPlayerPreLoginEvent.Result result, String message) {
+    @SuppressWarnings("null")
+    public void disallowPlayer(@NotNull org.bukkit.event.player.AsyncPlayerPreLoginEvent event, @NotNull org.bukkit.event.player.AsyncPlayerPreLoginEvent.Result result, @NotNull String message) {
         // Modern Paper/Folia API expects native net.kyori.adventure.text.Component
         // We use the provided LegacyComponentSerializer to convert our string
-        event.disallow(result, net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer.legacySection().deserialize(message));
+        event.disallow(result, net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer.legacySection().deserialize(Objects.requireNonNull(message)));
     }
 
     @Override
-    public void kickPlayer(org.bukkit.entity.Player player, String message) {
-        player.kick(net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer.legacySection().deserialize(message));
+    @SuppressWarnings("null")
+    public void kickPlayer(@NotNull org.bukkit.entity.Player player, @NotNull String message) {
+        player.kick(net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer.legacySection().deserialize(Objects.requireNonNull(message)));
     }
 }

--- a/src/main/java/com/digitalserverhost/plugins/utils/PlatformBridge.java
+++ b/src/main/java/com/digitalserverhost/plugins/utils/PlatformBridge.java
@@ -1,6 +1,8 @@
 package com.digitalserverhost.plugins.utils;
 
+import org.jetbrains.annotations.NotNull;
+
 public interface PlatformBridge {
-    void disallowPlayer(org.bukkit.event.player.AsyncPlayerPreLoginEvent event, org.bukkit.event.player.AsyncPlayerPreLoginEvent.Result result, String message);
-    void kickPlayer(org.bukkit.entity.Player player, String message);
+    void disallowPlayer(@NotNull org.bukkit.event.player.AsyncPlayerPreLoginEvent event, @NotNull org.bukkit.event.player.AsyncPlayerPreLoginEvent.Result result, @NotNull String message);
+    void kickPlayer(@NotNull org.bukkit.entity.Player player, @NotNull String message);
 }

--- a/src/main/java/com/digitalserverhost/plugins/utils/PlayerData.java
+++ b/src/main/java/com/digitalserverhost/plugins/utils/PlayerData.java
@@ -625,7 +625,7 @@ public class PlayerData {
             this.isOnShoulderRight = isOnShoulderRight;
         }
 
-        @SuppressWarnings("deprecation")
+        @SuppressWarnings({"deprecation", "null"})
         public CompanionSnapshot(org.bukkit.entity.Entity entity) {
             this.entityType = entity.getType().name();
             this.customName = entity.getCustomName();
@@ -647,8 +647,7 @@ public class PlayerData {
 
             String serializedNbt = null;
             try {
-                serializedNbt = de.tr7zw.changeme.nbtapi.NBT.get(entity,
-                        (java.util.function.Function<de.tr7zw.changeme.nbtapi.iface.ReadableNBT, String>) Object::toString);
+                serializedNbt = de.tr7zw.changeme.nbtapi.NBT.get(entity, Object::toString);
             } catch (Exception _) {
                 // NBTAPI unavailable or failed — companion saved without raw NBT
             }

--- a/src/main/resources/bungee.yml
+++ b/src/main/resources/bungee.yml
@@ -1,4 +1,4 @@
 name: mc-data-bridge
-version: 2.1.7
+version: 2.1.8
 main: com.digitalserverhost.plugins.proxy.bungee.BungeeMCDataBridge
 author: DigitalServerHost

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,5 +1,5 @@
 main: com.digitalserverhost.plugins.MCDataBridge
-version: 2.1.7
+version: 2.1.8
 name: mc-data-bridge
 author: DigitalServerHost
 api-version: 1.21
@@ -8,6 +8,12 @@ softdepend: [FastLogin, AuthMe]
 permissions:
   databridge.admin:
     description: Allows use of admin commands for MC Data Bridge
+    default: op
+  databridge.inspect:
+    description: Allows view-only inspection of player data and inventories
+    default: op
+  databridge.inspect.edit:
+    description: Allows interactive editing of player data and inventories
     default: op
 commands:
   databridge:

--- a/src/main/resources/purpur.yml
+++ b/src/main/resources/purpur.yml
@@ -1,5 +1,5 @@
 main: com.digitalserverhost.plugins.MCDataBridge
-version: 2.1.7
+version: 2.1.8
 name: mc-data-bridge
 author: DigitalServerHost
 api-version: 1.21
@@ -7,6 +7,12 @@ folia-supported: true
 permissions:
   databridge.admin:
     description: Allows use of admin commands for MC Data Bridge
+    default: op
+  databridge.inspect:
+    description: Allows view-only inspection of player data and inventories
+    default: op
+  databridge.inspect.edit:
+    description: Allows interactive editing of player data and inventories
     default: op
 commands:
   databridge:

--- a/src/main/resources/velocity-plugin.json
+++ b/src/main/resources/velocity-plugin.json
@@ -1,7 +1,7 @@
 {
   "id": "mc-data-bridge",
   "name": "mc-data-bridge",
-  "version": "2.1.7",
+  "version": "2.1.8",
   "description": "A data bridge for Minecraft servers.",
   "authors": [
     "DigitalServerHost"

--- a/src/main/resources/waterfall.yml
+++ b/src/main/resources/waterfall.yml
@@ -1,4 +1,4 @@
 name: mc-data-bridge
-version: 2.1.7
+version: 2.1.8
 main: com.digitalserverhost.plugins.proxy.bungee.BungeeMCDataBridge
 author: DigitalServerHost

--- a/src/test/java/com/digitalserverhost/plugins/commands/BridgeCommandTest.java
+++ b/src/test/java/com/digitalserverhost/plugins/commands/BridgeCommandTest.java
@@ -1,0 +1,79 @@
+package com.digitalserverhost.plugins.commands;
+
+import com.digitalserverhost.plugins.managers.DatabaseManager;
+import com.digitalserverhost.plugins.utils.DataManagementGUI;
+import org.bukkit.command.Command;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockmc.mockmc.MockMC;
+import org.mockmc.mockmc.ServerMock;
+import org.mockmc.mockmc.entity.PlayerMock;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+class BridgeCommandTest {
+
+    private ServerMock server;
+    private DatabaseManager mockDatabaseManager;
+    private DataManagementGUI mockGuiManager;
+    private Command mockCommand;
+
+    @BeforeEach
+    void setup() {
+        server = MockMC.mock();
+        mockDatabaseManager = mock(DatabaseManager.class);
+        mockGuiManager = mock(DataManagementGUI.class);
+        mockCommand = mock(Command.class);
+    }
+
+    @AfterEach
+    void tearDown() {
+        MockMC.unmock();
+    }
+
+    @Test
+    void testTabCompletionSubcommands() {
+        BridgeCommand cmd = new BridgeCommand(mockDatabaseManager, mockGuiManager);
+        PlayerMock admin = server.addPlayer("AdminUser");
+        admin.setOp(true);
+
+        List<String> arg0Completions = cmd.onTabComplete(admin, mockCommand, "databridge", new String[]{""});
+        assertNotNull(arg0Completions);
+        assertTrue(arg0Completions.contains("unlock"));
+        assertTrue(arg0Completions.contains("inspect"));
+        assertTrue(arg0Completions.contains("invsee"));
+        assertTrue(arg0Completions.contains("endersee"));
+        assertTrue(arg0Completions.contains("migrate"));
+    }
+
+    @Test
+    void testTabCompletionEditFlag() {
+        BridgeCommand cmd = new BridgeCommand(mockDatabaseManager, mockGuiManager);
+        PlayerMock admin = server.addPlayer("AdminUser");
+        admin.setOp(true);
+
+        List<String> invseeArg2 = cmd.onTabComplete(admin, mockCommand, "databridge", new String[]{"invsee", "TargetPlayer", "-"});
+        assertNotNull(invseeArg2);
+        assertTrue(invseeArg2.contains("--edit"));
+
+        List<String> inspectArg3 = cmd.onTabComplete(admin, mockCommand, "databridge", new String[]{"inspect", "TargetPlayer", "inventory", "-"});
+        assertNotNull(inspectArg3);
+        assertTrue(inspectArg3.contains("--edit"));
+    }
+
+    @Test
+    void testTabCompletionPlayerNames() {
+        BridgeCommand cmd = new BridgeCommand(mockDatabaseManager, mockGuiManager);
+        server.addPlayer("Alice");
+        PlayerMock admin = server.addPlayer("Bob");
+        admin.setOp(true);
+
+        List<String> playerCompletions = cmd.onTabComplete(admin, mockCommand, "databridge", new String[]{"invsee", "Al"});
+        assertNotNull(playerCompletions);
+        assertTrue(playerCompletions.contains("Alice"));
+    }
+}

--- a/src/test/java/com/digitalserverhost/plugins/listeners/PlayerFlowTest.java
+++ b/src/test/java/com/digitalserverhost/plugins/listeners/PlayerFlowTest.java
@@ -287,4 +287,35 @@ class PlayerFlowTest {
         // Verify save was NOT called again
         verify(mockDatabaseManager, never()).saveAndReleaseLockComponents(eq(mockPlugin), any(PlayerData.class), anyString(), eq(uuid), anyString(), any());
     }
+
+    @Test
+    void testItemDuplicationProtectionDuringSwitching() {
+        PlayerListener listener = new PlayerListener(mockDatabaseManager, mockPlugin);
+        PlayerMock player = server.addPlayer();
+        UUID uuid = player.getUniqueId();
+
+        // Initially not locked
+        org.junit.jupiter.api.Assertions.assertFalse(listener.isPlayerLocked(uuid));
+
+        // Trigger SaveAndRelease plugin message
+        @SuppressWarnings("UnstableApiUsage")
+        com.google.common.io.ByteArrayDataOutput out = com.google.common.io.ByteStreams.newDataOutput();
+        out.writeUTF("SaveAndRelease");
+        out.writeUTF(java.util.Objects.requireNonNull(uuid.toString()));
+        listener.onPluginMessageReceived("mc-data-bridge:main", player, out.toByteArray());
+
+        // Player should now be locked
+        org.junit.jupiter.api.Assertions.assertTrue(listener.isPlayerLocked(uuid));
+
+        // Simulate PlayerDropItemEvent
+        org.bukkit.entity.Item itemMock = mock(org.bukkit.entity.Item.class);
+        org.bukkit.event.player.PlayerDropItemEvent dropEvent = new org.bukkit.event.player.PlayerDropItemEvent(player, itemMock);
+        listener.onPlayerDropItem(dropEvent);
+        org.junit.jupiter.api.Assertions.assertTrue(dropEvent.isCancelled(), "PlayerDropItemEvent should be cancelled during server transfer");
+
+        // Simulate PlayerInteractEvent
+        org.bukkit.event.player.PlayerInteractEvent interactEvent = new org.bukkit.event.player.PlayerInteractEvent(player, org.bukkit.event.block.Action.RIGHT_CLICK_BLOCK, null, null, org.bukkit.block.BlockFace.UP);
+        listener.onPlayerInteract(interactEvent);
+        org.junit.jupiter.api.Assertions.assertEquals(org.bukkit.event.Event.Result.DENY, interactEvent.useInteractedBlock(), "PlayerInteractEvent block result should be DENY during server transfer");
+    }
 }

--- a/src/test/java/com/digitalserverhost/plugins/listeners/PlayerSyncTest.java
+++ b/src/test/java/com/digitalserverhost/plugins/listeners/PlayerSyncTest.java
@@ -316,6 +316,7 @@ class PlayerSyncTest {
     }
 
     @Test
+    @SuppressWarnings("null")
     void testAllStatisticsSync() throws Exception {
         // 1. Prepare Source Player Stats
         org.bukkit.entity.Player sourcePlayer = mock(org.bukkit.entity.Player.class);

--- a/src/test/java/com/digitalserverhost/plugins/managers/DatabaseManagerTest.java
+++ b/src/test/java/com/digitalserverhost/plugins/managers/DatabaseManagerTest.java
@@ -175,4 +175,63 @@ class DatabaseManagerTest {
         assertFalse(result);
         verify(mockConnection, never()).prepareStatement(contains("UPDATE `player_data` SET uuid = ?"));
     }
+
+    @Test
+    void testBlobSerialization_JsonFormat() {
+        // serializationFormat is "json" by default in the test constructor
+        java.util.List<String> list = java.util.List.of("{\"item\":\"1\"}", "{\"item\":\"2\"}");
+        byte[] blob = databaseManager.serializeListToBlob(list);
+        
+        assertNotNull(blob);
+        String json = new String(blob, java.nio.charset.StandardCharsets.UTF_8);
+        assertTrue(json.startsWith("["));
+        
+        java.util.List<String> result = databaseManager.deserializeListFromBlob(blob);
+        assertEquals(list, result);
+    }
+
+    @Test
+    void testBlobSerialization_BinaryFormat() throws Exception {
+        // Set serializationFormat to "binary" via reflection
+        java.lang.reflect.Field field = DatabaseManager.class.getDeclaredField("serializationFormat");
+        field.setAccessible(true);
+        field.set(databaseManager, "binary");
+        
+        java.util.List<String> list = java.util.List.of("{\"item\":\"1\"}", "{\"item\":\"2\"}");
+        byte[] blob = databaseManager.serializeListToBlob(list);
+        
+        assertNotNull(blob);
+        // Binary format should not start with '['
+        assertTrue(blob.length > 0 && blob[0] != (byte) '[');
+        
+        java.util.List<String> result = databaseManager.deserializeListFromBlob(blob);
+        assertEquals(list, result);
+    }
+
+    @Test
+    void testBlobDeserialization_AutoDetect() throws Exception {
+        // Case 1: Database has binary data, but configured format is json
+        java.lang.reflect.Field field = DatabaseManager.class.getDeclaredField("serializationFormat");
+        field.setAccessible(true);
+        
+        // 1. Serialize in binary
+        field.set(databaseManager, "binary");
+        java.util.List<String> list = java.util.List.of("{\"item\":\"1\"}", "{\"item\":\"2\"}");
+        byte[] binaryBlob = databaseManager.serializeListToBlob(list);
+        
+        // 2. Configure to json, deserialize
+        field.set(databaseManager, "json");
+        java.util.List<String> result1 = databaseManager.deserializeListFromBlob(binaryBlob);
+        assertEquals(list, result1);
+
+        // Case 2: Database has json data, but configured format is binary
+        // 1. Serialize in json
+        field.set(databaseManager, "json");
+        byte[] jsonBlob = databaseManager.serializeListToBlob(list);
+        
+        // 2. Configure to binary, deserialize
+        field.set(databaseManager, "binary");
+        java.util.List<String> result2 = databaseManager.deserializeListFromBlob(jsonBlob);
+        assertEquals(list, result2);
+    }
 }


### PR DESCRIPTION
# Release v2.1.8: Item Duplication Exploit Protection, Inspector GUI with Edit Mode, Tab Completion, and Granular Permissions

## Description

This pull request introduces **MC Data Bridge v2.1.8**, containing critical security fixes, administrative GUI features, comprehensive tab completion, database auto-schema maintenance, and modern platform compatibility updates.

### 🔑 Key Highlights:

1. **🛡 Item Duplication Exploit Protection (#30):**
   - Implemented automatic inventory window closure during server transfers to snapshot player state cleanly.
   - Enforced transfer locks to cancel item drops, item pickups, container clicks, inventory drags, and entity interactions during active server switches.
   - *Special thanks to **@AllenLinong** for discovering and reporting this critical exploit!*

2. **🔍 Interactive Inventory & Ender Chest Inspector (`invsee` / `endersee`) (#29, #31):**
   - Added `/databridge invsee <player> [--edit]` and `/databridge endersee <player> [--edit]` command aliases.
   - **Safe View-Only Mode (Default):** Opened via **Left-Click** or standard inspection to safely view offline/cross-server inventories without risking accidental edits (`databridge.inspect`).
   - **Interactive Edit Mode:** Opened via **Right-Click** or `--edit` flag to edit items directly in offline/cross-server player inventories or ender chests (`databridge.inspect.edit`).
   - **Database Auto-Save:** Automatically serializes and saves modified inventories back to the database on GUI close (`InventoryCloseEvent`).
   - *Thanks to **@NoLiver92** for requesting dedicated offline inventory/ender chest editing!*

3. **⌨️ Comprehensive Tab Completion (#29):**
   - Implemented full `TabExecutor` / Brigadier auto-completion for all subcommands (`inspect`, `invsee`, `endersee`, `unlock`, `migrate`), online player names, view types (`inventory`, `enderchest`), and command flags (`--edit`).

4. **🗄 Database Schema Auto-Migration & Paper 26.2 Parity:**
   - Added `auto-update-schema: true` config option to automatically upgrade `vanilla_stats_json` from `TEXT` to `LONGTEXT` / `TEXT` without data truncation.
   - Refactored GUI handlers to use a custom `DataBridgeGUIHolder` (`InventoryHolder`) to eliminate session race conditions and title string parsing issues.

Fixes #29
Fixes #30
Fixes #31

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
